### PR TITLE
Handle polling interval updates from options

### DIFF
--- a/enphase_envoy_cloud_control/__init__.py
+++ b/enphase_envoy_cloud_control/__init__.py
@@ -5,10 +5,12 @@ Version: 1.5.4
 
 from __future__ import annotations
 import logging
+from datetime import timedelta
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
-from .const import DOMAIN
+from .const import DOMAIN, DEFAULT_POLL_INTERVAL
 from .coordinator import EnphaseCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -22,6 +24,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     coordinator = EnphaseCoordinator(hass, entry)
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+
+    # React to option updates without requiring a full reload so that
+    # the polling interval is adjusted immediately.
+    entry.async_on_unload(
+        entry.add_update_listener(_async_handle_options_update)
+    )
 
     # Run initial refresh (non-blocking)
     await coordinator.async_config_entry_first_refresh()
@@ -55,3 +63,27 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.debug("[Enphase] Integration data cleared from memory.")
 
     return unload_ok
+
+
+async def _async_handle_options_update(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Apply updated options (e.g. polling interval) to the coordinator."""
+    coordinator = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    if not coordinator:
+        _LOGGER.debug("[Enphase] Options updated but coordinator not initialised yet.")
+        return
+
+    poll_interval = entry.options.get("poll_interval", DEFAULT_POLL_INTERVAL)
+    try:
+        poll_interval = int(poll_interval)
+    except (TypeError, ValueError):
+        _LOGGER.warning(
+            "[Enphase] Invalid poll interval '%s' in options; falling back to default.",
+            poll_interval,
+        )
+        poll_interval = DEFAULT_POLL_INTERVAL
+
+    coordinator.update_interval = timedelta(seconds=poll_interval)
+    _LOGGER.info("[Enphase] Polling interval updated to %ss via options.", poll_interval)
+
+    # Trigger a refresh so the new interval is respected immediately.
+    await coordinator.async_request_refresh()


### PR DESCRIPTION
## Summary
- register an options update listener so the coordinator picks up changes to the polling interval
- validate and apply the new interval immediately without requiring a reload

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6903a6ff90648325b352b36f71d9aea2