### PR TITLE
Load auth cache off event loop, fix options flow, and make post-action refresh thread-safe

### DIFF
--- a/enphase_envoy_cloud_control/__init__.py
+++ b/enphase_envoy_cloud_control/__init__.py
@@ -48,6 +48,31 @@ ADD_SCHEDULE_SCHEMA = vol.Schema(
 
 _SCHEDULE_ID_REGEX = r"^[0-9a-fA-F-]{6,}$"
 
+
+def _normalize_schedule_ids(raw: Any) -> list[str]:
+    schedule_ids: list[str] = []
+    if raw is None:
+        return schedule_ids
+
+    if isinstance(raw, (list, tuple, set)):
+        candidates = [str(val) for val in raw]
+    else:
+        candidates = [str(raw)]
+
+    for candidate in candidates:
+        if not candidate:
+            continue
+        extracted_ids = re.findall(r"[0-9a-fA-F-]{6,}", candidate)
+        if extracted_ids:
+            schedule_ids.extend(extracted_ids)
+            continue
+        schedule_ids.extend(
+            [part for part in re.split(r"[,\s]+", candidate) if part]
+        )
+
+    schedule_ids = [sched_id.strip().strip("'\"") for sched_id in schedule_ids]
+    return [sched_id for sched_id in schedule_ids if sched_id]
+
 DELETE_SCHEDULE_SCHEMA = vol.Schema(
     {
         vol.Optional("config_entry_id"): cv.string,
@@ -270,24 +295,17 @@ def _register_services(hass: HomeAssistant) -> None:
         async_call_later(
             hass,
             5,
-            lambda _: hass.async_create_task(_post_action_refresh(coordinator)),
+            lambda _: _schedule_post_action_refresh(hass, coordinator),
         )
 
     async def async_delete_schedule_service(call: ServiceCall) -> None:
         coordinator = _get_coordinator_from_call(hass, call)
-        schedule_ids: list[str] = []
         if call.data.get("schedule_ids"):
-            raw = call.data["schedule_ids"]
-            if isinstance(raw, str):
-                schedule_ids = [val.strip() for val in raw.split(",")]
-            else:
-                schedule_ids = [str(val).strip() for val in raw]
+            schedule_ids = _normalize_schedule_ids(call.data["schedule_ids"])
         elif call.data.get("schedule_id"):
-            schedule_ids = [call.data["schedule_id"].strip()]
+            schedule_ids = _normalize_schedule_ids(call.data["schedule_id"])
         else:
             raise HomeAssistantError("Provide schedule_id or schedule_ids to delete.")
-
-        schedule_ids = [sched_id for sched_id in schedule_ids if sched_id]
         if not schedule_ids:
             raise HomeAssistantError("Provide at least one schedule ID to delete.")
 
@@ -337,7 +355,7 @@ def _register_services(hass: HomeAssistant) -> None:
         async_call_later(
             hass,
             5,
-            lambda _: hass.async_create_task(_post_action_refresh(coordinator)),
+            lambda _: _schedule_post_action_refresh(hass, coordinator),
         )
 
     async def async_validate_schedule_service(call: ServiceCall) -> None:
@@ -400,6 +418,15 @@ async def _post_action_refresh(coordinator: EnphaseCoordinator) -> None:
         await coordinator.async_request_refresh()
     except Exception as exc:  # pragma: no cover - defensive log
         _LOGGER.warning("[Enphase] Post-action refresh failed: %s", exc)
+
+
+def _schedule_post_action_refresh(
+    hass: HomeAssistant, coordinator: EnphaseCoordinator
+) -> None:
+    """Schedule a post-action refresh from any thread safely."""
+    hass.loop.call_soon_threadsafe(
+        hass.async_create_task, _post_action_refresh(coordinator)
+    )
 
 
 def _collect_schedules(coordinator: EnphaseCoordinator, mode: str) -> list[dict[str, Any]]:

--- a/enphase_envoy_cloud_control/coordinator.py
+++ b/enphase_envoy_cloud_control/coordinator.py
@@ -115,6 +115,7 @@ class EnphaseCoordinator(DataUpdateCoordinator):
 
     async def async_initialize_auth(self) -> None:
         """Ensure authentication is ready and persist discovered IDs."""
+        await self.hass.async_add_executor_job(self.client.load_cache)
         ids = await self.hass.async_add_executor_job(self.client.ensure_authenticated)
         if not ids:
             return

--- a/enphase_envoy_cloud_control/enphase_client.py
+++ b/enphase_envoy_cloud_control/enphase_client.py
@@ -31,13 +31,12 @@ class EnphaseClient:
         self.xsrf_token: str | None = None
         self.cookies: dict | None = None
         self.jwt_exp: int | None = None
-        self._load_cache()
 
     # -------------------------------------------------------------------------
     # CACHE
     # -------------------------------------------------------------------------
 
-    def _load_cache(self):
+    def load_cache(self):
         """Load cached JWT/XSRF tokens if present."""
         try:
             if os.path.exists(CACHE_FILE):

--- a/enphase_envoy_cloud_control/options_flow.py
+++ b/enphase_envoy_cloud_control/options_flow.py
@@ -16,7 +16,7 @@ class EnphaseOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle options for Enphase Envoy Cloud Control."""
 
     def __init__(self, config_entry: config_entries.ConfigEntry):
-        self.config_entry = config_entry
+        self._config_entry = config_entry
         self._last_error: str | None = None
 
     async def async_step_init(self, user_input=None):
@@ -34,7 +34,7 @@ class EnphaseOptionsFlowHandler(config_entries.OptionsFlow):
             {
                 vol.Optional(
                     "poll_interval",
-                    default=self.config_entry.options.get(
+                    default=self._config_entry.options.get(
                         "poll_interval", DEFAULT_POLL_INTERVAL
                     ),
                 ): int,
@@ -59,7 +59,7 @@ class EnphaseOptionsFlowHandler(config_entries.OptionsFlow):
 
             if not errors:
                 payload = {
-                    "config_entry_id": self.config_entry.entry_id,
+                    "config_entry_id": self._config_entry.entry_id,
                     "schedule_type": user_input["schedule_type"],
                     "start_time": user_input["start_time"],
                     "end_time": user_input["end_time"],
@@ -83,7 +83,7 @@ class EnphaseOptionsFlowHandler(config_entries.OptionsFlow):
                     )
                 else:
                     return self.async_create_entry(
-                        title="", data=dict(self.config_entry.options)
+                        title="", data=dict(self._config_entry.options)
                     )
 
         schedule_type_selector = selector.SelectSelector(
@@ -155,7 +155,7 @@ class EnphaseOptionsFlowHandler(config_entries.OptionsFlow):
                 errors["confirm"] = "required"
             else:
                 payload = {
-                    "config_entry_id": self.config_entry.entry_id,
+                    "config_entry_id": self._config_entry.entry_id,
                     "schedule_ids": user_input["schedule_ids"],
                     "confirm": True,
                 }
@@ -176,7 +176,7 @@ class EnphaseOptionsFlowHandler(config_entries.OptionsFlow):
                     )
                 else:
                     return self.async_create_entry(
-                        title="", data=dict(self.config_entry.options)
+                        title="", data=dict(self._config_entry.options)
                     )
 
         schedule_selector = selector.SelectSelector(
@@ -204,7 +204,7 @@ class EnphaseOptionsFlowHandler(config_entries.OptionsFlow):
 
     def _schedule_options(self) -> list[selector.SelectOptionDict]:
         """Build schedule options for the delete form."""
-        coordinator = self.hass.data.get(DOMAIN, {}).get(self.config_entry.entry_id)
+        coordinator = self.hass.data.get(DOMAIN, {}).get(self._config_entry.entry_id)
         if not coordinator or not getattr(coordinator, "data", None):
             return []
 


### PR DESCRIPTION
### Motivation
- Prevent blocking the Home Assistant event loop and avoid runtime errors when reading the auth cache and scheduling refreshes. 
- Avoid attribute errors from the options flow when Home Assistant expects `config_entry` to be a property without a setter. 
- Ensure delayed post-action refreshes are scheduled safely from threads other than the event loop.

### Description
- Move the blocking cache read out of the `EnphaseClient` constructor by renaming `_load_cache` to `load_cache` and calling it in the coordinator via `hass.async_add_executor_job` in `async_initialize_auth` (`enphase_client.py`, `coordinator.py`).
- Replace direct uses of `self.config_entry` in the options flow with a stored `self._config_entry` and update all lookups and payloads to use `self._config_entry` to avoid setting the `config_entry` property (`options_flow.py`).
- Add a thread-safe helper `_schedule_post_action_refresh` and update delayed refresh calls to use it so `hass.async_create_task` is only invoked from the event loop via `hass.loop.call_soon_threadsafe` (`__init__.py`).

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983788be08083258cf912079418c3c6)