### PR TITLE
Add update_schedule service and editor UI entities

### DIFF
--- a/enphase_envoy_cloud_control/editor.py
+++ b/enphase_envoy_cloud_control/editor.py
@@ -1,0 +1,168 @@
+"""Helpers for schedule editor state and normalization."""
+
+from __future__ import annotations
+
+import re
+from datetime import time
+from typing import Any
+
+from .const import DOMAIN
+from .coordinator import EnphaseCoordinator
+
+DAY_ORDER: list[tuple[str, int]] = [
+    ("mon", 1),
+    ("tue", 2),
+    ("wed", 3),
+    ("thu", 4),
+    ("fri", 5),
+    ("sat", 6),
+    ("sun", 7),
+]
+DAY_KEY_BY_INDEX = {index: key for key, index in DAY_ORDER}
+
+
+def default_day_flags() -> dict[str, bool]:
+    """Return day flag defaults (all false)."""
+    return {key: False for key, _ in DAY_ORDER}
+
+
+def default_editor_state() -> dict[str, Any]:
+    """Return a fresh editor state mapping."""
+    return {
+        "selected_schedule_id": None,
+        "schedule_type": "cfg",
+        "start_time": "00:00",
+        "end_time": "00:00",
+        "limit": 0,
+        "days": default_day_flags(),
+    }
+
+
+def default_new_editor_state() -> dict[str, Any]:
+    """Return default state for new schedules."""
+    return {
+        "schedule_type": "cfg",
+        "start_time": "00:00",
+        "end_time": "00:00",
+        "limit": 0,
+        "days": default_day_flags(),
+    }
+
+
+def get_entry_data(hass, entry_id: str) -> dict[str, Any]:
+    """Return stored entry data."""
+    return hass.data[DOMAIN][entry_id]
+
+
+def get_coordinator(hass, entry_id: str) -> EnphaseCoordinator:
+    """Return coordinator from entry data."""
+    return get_entry_data(hass, entry_id)["coordinator"]
+
+
+def editor_days_from_list(days: list[int]) -> dict[str, bool]:
+    """Convert list of ints into editor day flags."""
+    flags = default_day_flags()
+    for day in days:
+        key = DAY_KEY_BY_INDEX.get(day)
+        if key:
+            flags[key] = True
+    return flags
+
+
+def days_list_from_editor(flags: dict[str, bool]) -> list[int]:
+    """Convert editor day flags into list of ints."""
+    return [index for key, index in DAY_ORDER if flags.get(key)]
+
+
+def _normalize_time(value: Any) -> str:
+    if isinstance(value, time):
+        return value.strftime("%H:%M")
+    if value is None:
+        return "00:00"
+    if isinstance(value, (int, float)):
+        return f"{int(value):02d}:00"
+    value_str = str(value)
+    match = re.search(r"(\d{2}:\d{2})", value_str)
+    if match:
+        return match.group(1)
+    return value_str[:5]
+
+
+def _normalize_days(raw: Any) -> list[int]:
+    if not raw:
+        return []
+    if isinstance(raw, dict):
+        return sorted(
+            int(key)
+            for key, enabled in raw.items()
+            if enabled and str(key).isdigit()
+        )
+    if isinstance(raw, (list, tuple, set)):
+        values = list(raw)
+    else:
+        values = re.split(r"[,\s]+", str(raw))
+    days: list[int] = []
+    for value in values:
+        try:
+            day = int(value)
+        except (TypeError, ValueError):
+            continue
+        if 1 <= day <= 7:
+            days.append(day)
+    return sorted(set(days))
+
+
+def _collect_schedules(coordinator: EnphaseCoordinator, mode: str) -> list[dict[str, Any]]:
+    data_root = coordinator.data or {}
+    schedule_block = data_root.get("data", {}).get(f"{mode}Control", {})
+    schedules = schedule_block.get("schedules")
+    if isinstance(schedules, list):
+        return schedules
+
+    fallback = data_root.get("schedules", {})
+    if isinstance(fallback, dict):
+        candidate = fallback.get(mode)
+        if isinstance(candidate, dict) and isinstance(candidate.get("details"), list):
+            return candidate["details"]
+        if isinstance(candidate, list):
+            return candidate
+        inner = fallback.get("data", {}).get(mode)
+        if isinstance(inner, dict) and isinstance(inner.get("details"), list):
+            return inner["details"]
+        if isinstance(inner, list):
+            return inner
+
+    cached = getattr(coordinator.client, "_last_schedules", None)
+    if isinstance(cached, dict):
+        candidate = cached.get(mode)
+        if isinstance(candidate, dict) and isinstance(candidate.get("details"), list):
+            return candidate["details"]
+        if isinstance(candidate, list):
+            return candidate
+
+    return []
+
+
+def normalize_schedules(coordinator: EnphaseCoordinator) -> list[dict[str, Any]]:
+    """Return normalized schedules for all modes."""
+    normalized: list[dict[str, Any]] = []
+    for mode in ("cfg", "dtg", "rbd"):
+        for schedule in _collect_schedules(coordinator, mode):
+            schedule_id = schedule.get("scheduleId")
+            if schedule_id is None:
+                continue
+            normalized.append(
+                {
+                    "id": str(schedule_id),
+                    "type": str(schedule.get("scheduleType", mode)).lower(),
+                    "start": _normalize_time(schedule.get("startTime")),
+                    "end": _normalize_time(schedule.get("endTime")),
+                    "limit": int(schedule.get("limit") or schedule.get("powerLimit") or 0),
+                    "days": _normalize_days(
+                        schedule.get("days")
+                        or schedule.get("daysOfWeek")
+                        or schedule.get("dayOfWeek")
+                    ),
+                }
+            )
+    return normalized

--- a/enphase_envoy_cloud_control/number.py
+++ b/enphase_envoy_cloud_control/number.py
@@ -1,0 +1,57 @@
+"""Number entities for schedule editing."""
+
+from __future__ import annotations
+
+from homeassistant.components.number import NumberEntity
+
+from .const import DOMAIN
+from .editor import get_entry_data
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up schedule number entities."""
+    async_add_entities(
+        [
+            EnphaseScheduleLimit(entry.entry_id, False),
+            EnphaseScheduleLimit(entry.entry_id, True),
+        ],
+        True,
+    )
+
+
+class EnphaseScheduleLimit(NumberEntity):
+    """Number entity for schedule limit."""
+
+    _attr_native_min_value = 0
+    _attr_native_max_value = 100
+    _attr_native_step = 1
+    _attr_native_unit_of_measurement = "%"
+
+    def __init__(self, entry_id: str, is_new: bool):
+        self.entry_id = entry_id
+        self.is_new = is_new
+        schedule_label = "New Schedule" if is_new else "Schedule"
+        self._attr_name = f"Enphase {schedule_label} Limit"
+        suffix = "new" if is_new else "edit"
+        self._attr_unique_id = f"{entry_id}_{suffix}_limit"
+
+    @property
+    def native_value(self) -> float | None:
+        entry_data = get_entry_data(self.hass, self.entry_id)
+        editor_key = "new_editor" if self.is_new else "editor"
+        return float(entry_data[editor_key].get("limit", 0))
+
+    async def async_set_native_value(self, value: float) -> None:
+        entry_data = get_entry_data(self.hass, self.entry_id)
+        editor_key = "new_editor" if self.is_new else "editor"
+        entry_data[editor_key]["limit"] = int(value)
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self.entry_id)},
+            "name": "Enphase Envoy Cloud Control",
+            "manufacturer": "Enphase Energy",
+            "model": "Envoy Cloud API",
+        }

--- a/enphase_envoy_cloud_control/options_flow.py
+++ b/enphase_envoy_cloud_control/options_flow.py
@@ -218,7 +218,8 @@ class EnphaseOptionsFlowHandler(config_entries.OptionsFlow):
 
     def _schedule_options(self) -> list[selector.SelectOptionDict]:
         """Build schedule options for the delete form."""
-        coordinator = self.hass.data.get(DOMAIN, {}).get(self._config_entry.entry_id)
+        entry_data = self.hass.data.get(DOMAIN, {}).get(self._config_entry.entry_id)
+        coordinator = entry_data.get("coordinator") if isinstance(entry_data, dict) else None
         if not coordinator or not getattr(coordinator, "data", None):
             return []
 

--- a/enphase_envoy_cloud_control/select.py
+++ b/enphase_envoy_cloud_control/select.py
@@ -1,0 +1,112 @@
+"""Select entities for schedule editing."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.select import SelectEntity
+
+from .const import DOMAIN
+from .editor import (
+    editor_days_from_list,
+    get_coordinator,
+    get_entry_data,
+    normalize_schedules,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up schedule select entities."""
+    coordinator = get_coordinator(hass, entry.entry_id)
+    async_add_entities(
+        [
+            EnphaseScheduleSelect(coordinator, entry.entry_id),
+            EnphaseNewScheduleTypeSelect(entry.entry_id),
+        ],
+        True,
+    )
+
+
+class EnphaseScheduleSelect(SelectEntity):
+    """Select the active schedule to edit."""
+
+    _attr_name = "Enphase Schedule Selected"
+    _attr_icon = "mdi:calendar-edit"
+
+    def __init__(self, coordinator, entry_id: str):
+        self.coordinator = coordinator
+        self.entry_id = entry_id
+        self._attr_unique_id = f"{entry_id}_schedule_selected"
+
+    @property
+    def options(self):
+        schedules = normalize_schedules(self.coordinator)
+        return [schedule["id"] for schedule in schedules]
+
+    @property
+    def current_option(self):
+        editor = get_entry_data(self.hass, self.entry_id)["editor"]
+        return editor.get("selected_schedule_id")
+
+    async def async_select_option(self, option: str) -> None:
+        entry_data = get_entry_data(self.hass, self.entry_id)
+        schedules = normalize_schedules(self.coordinator)
+        match = next((sched for sched in schedules if sched["id"] == option), None)
+        editor = entry_data["editor"]
+        editor["selected_schedule_id"] = option
+        if match:
+            editor["schedule_type"] = match.get("type", "cfg")
+            editor["start_time"] = match.get("start", "00:00")
+            editor["end_time"] = match.get("end", "00:00")
+            editor["limit"] = int(match.get("limit", 0))
+            editor["days"] = editor_days_from_list(match.get("days", []))
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self.entry_id)},
+            "name": "Enphase Envoy Cloud Control",
+            "manufacturer": "Enphase Energy",
+            "model": "Envoy Cloud API",
+        }
+
+
+class EnphaseNewScheduleTypeSelect(SelectEntity):
+    """Select schedule type for a new schedule."""
+
+    _attr_name = "Enphase New Schedule Type"
+    _attr_icon = "mdi:calendar-plus"
+
+    def __init__(self, entry_id: str):
+        self.entry_id = entry_id
+        self._attr_unique_id = f"{entry_id}_new_schedule_type"
+        self._attr_options = ["cfg", "dtg", "rbd"]
+
+    @property
+    def options(self):
+        return list(self._attr_options)
+
+    @property
+    def current_option(self):
+        entry_data = get_entry_data(self.hass, self.entry_id)
+        return entry_data["new_editor"].get("schedule_type", "cfg")
+
+    async def async_select_option(self, option: str) -> None:
+        if option not in self._attr_options:
+            _LOGGER.warning("[Enphase] Invalid schedule type selected: %s", option)
+            return
+        entry_data = get_entry_data(self.hass, self.entry_id)
+        entry_data["new_editor"]["schedule_type"] = option
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self.entry_id)},
+            "name": "Enphase Envoy Cloud Control",
+            "manufacturer": "Enphase Energy",
+            "model": "Envoy Cloud API",
+        }

--- a/enphase_envoy_cloud_control/sensor.py
+++ b/enphase_envoy_cloud_control/sensor.py
@@ -5,14 +5,15 @@ from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers.entity import EntityCategory
 from .const import DOMAIN
+from .editor import normalize_schedules, get_coordinator
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up Enphase sensors from a config entry."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]
-    sensors = [EnphaseBatteryModesSensor(coordinator)]
+    coordinator = get_coordinator(hass, entry.entry_id)
+    sensors = [EnphaseBatteryModesSensor(coordinator), EnphaseSchedulesSummarySensor(coordinator)]
 
     # Add per-mode schedule sensors
     for mode in ["cfg", "dtg", "rbd"]:
@@ -94,6 +95,44 @@ class EnphaseBatteryModesSensor(CoordinatorEntity, SensorEntity):
     @property
     def device_info(self):
         """Ensure the sensor is attached to the shared Enphase device."""
+        return {
+            "identifiers": {(DOMAIN, self.coordinator.entry.entry_id)},
+            "name": "Enphase Envoy Cloud Control",
+            "manufacturer": "Enphase Energy",
+            "model": "Envoy Cloud API",
+        }
+
+
+class EnphaseSchedulesSummarySensor(CoordinatorEntity, SensorEntity):
+    """Normalized schedule list for editor usage."""
+
+    _attr_name = "Enphase Schedules Summary"
+    _attr_icon = "mdi:calendar-multiple"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator):
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.entry.entry_id}_schedules_summary"
+
+    @property
+    def state(self):
+        schedules = normalize_schedules(self.coordinator)
+        return str(len(schedules))
+
+    @property
+    def extra_state_attributes(self):
+        attrs = {
+            "schedules": normalize_schedules(self.coordinator),
+            "last_refresh": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S%z"),
+        }
+        if getattr(self.coordinator, "last_update_success_time", None):
+            t = self.coordinator.last_update_success_time
+            if isinstance(t, datetime):
+                attrs["last_successful_poll"] = t.strftime("%Y-%m-%dT%H:%M:%S%z")
+        return attrs
+
+    @property
+    def device_info(self):
         return {
             "identifiers": {(DOMAIN, self.coordinator.entry.entry_id)},
             "name": "Enphase Envoy Cloud Control",

--- a/enphase_envoy_cloud_control/services.yaml
+++ b/enphase_envoy_cloud_control/services.yaml
@@ -66,6 +66,82 @@ add_schedule:
             - label: "Sunday"
               value: "7"
 
+update_schedule:
+  name: "Update Schedule"
+  description: "Update an existing Enphase battery schedule via the Cloud API."
+  fields:
+    schedule_id:
+      name: "Schedule ID"
+      description: "Schedule ID to update."
+      required: true
+      selector:
+        text:
+    schedule_type:
+      name: "Schedule Type"
+      description: "Choose which mode to schedule"
+      required: true
+      selector:
+        select:
+          options:
+            - label: "Charge from Grid (CFG)"
+              value: "cfg"
+            - label: "Discharge to Grid (DTG)"
+              value: "dtg"
+            - label: "Restrict Battery Discharge (RBD)"
+              value: "rbd"
+    start_time:
+      name: "Start Time"
+      description: "Time the schedule starts (HH:MM)"
+      required: true
+      selector:
+        time:
+    end_time:
+      name: "End Time"
+      description: "Time the schedule ends (HH:MM)"
+      required: true
+      selector:
+        time:
+    limit:
+      name: "Limit"
+      description: "Battery power limit for this schedule (percentage)"
+      required: true
+      example: 80
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          mode: box
+          unit_of_measurement: "%"
+    days:
+      name: "Days of Week"
+      description: "Select days this schedule applies (1=Monday ... 7=Sunday)"
+      required: true
+      selector:
+        select:
+          multiple: true
+          options:
+            - label: "Monday"
+              value: "1"
+            - label: "Tuesday"
+              value: "2"
+            - label: "Wednesday"
+              value: "3"
+            - label: "Thursday"
+              value: "4"
+            - label: "Friday"
+              value: "5"
+            - label: "Saturday"
+              value: "6"
+            - label: "Sunday"
+              value: "7"
+    confirm:
+      name: "Confirm update"
+      description: "Enable to confirm this schedule should be updated."
+      required: true
+      selector:
+        boolean:
+
 delete_schedule:
   name: "Delete Schedule"
   description: "Remove an existing Enphase schedule using its scheduleId."

--- a/enphase_envoy_cloud_control/switch.py
+++ b/enphase_envoy_cloud_control/switch.py
@@ -4,18 +4,27 @@ import logging
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
+from .editor import DAY_ORDER, get_coordinator, get_entry_data
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
-    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = get_coordinator(hass, entry.entry_id)
     data = coordinator.data.get("data", {}) if coordinator.data else {}
     switches = []
 
     for key in ["cfgControl", "dtgControl", "rbdControl"]:
         if key in data:
             switches.append(EnphaseModeSwitch(coordinator, key))
+
+    for key, _ in DAY_ORDER:
+        switches.append(
+            EnphaseEditorDaySwitch(entry.entry_id, key, is_new=False)
+        )
+        switches.append(
+            EnphaseEditorDaySwitch(entry.entry_id, key, is_new=True)
+        )
 
     async_add_entities(switches, True)
 
@@ -66,6 +75,46 @@ class EnphaseModeSwitch(CoordinatorEntity, SwitchEntity):
         """Attach to Enphase Envoy Cloud device."""
         return {
             "identifiers": {(DOMAIN, self.coordinator.entry.entry_id)},
+            "name": "Enphase Envoy Cloud Control",
+            "manufacturer": "Enphase Energy",
+            "model": "Envoy Cloud API",
+        }
+
+
+class EnphaseEditorDaySwitch(SwitchEntity):
+    """Switch representing a weekday toggle for schedule editing."""
+
+    def __init__(self, entry_id: str, day_key: str, is_new: bool):
+        self.entry_id = entry_id
+        self.day_key = day_key
+        self.is_new = is_new
+        schedule_label = "New Schedule" if is_new else "Schedule"
+        self._attr_name = f"Enphase {schedule_label} {day_key.title()}"
+        suffix = "new" if is_new else "edit"
+        self._attr_unique_id = f"{entry_id}_{suffix}_{day_key}"
+
+    @property
+    def is_on(self) -> bool:
+        entry_data = get_entry_data(self.hass, self.entry_id)
+        editor_key = "new_editor" if self.is_new else "editor"
+        return bool(entry_data[editor_key]["days"].get(self.day_key))
+
+    async def async_turn_on(self) -> None:
+        entry_data = get_entry_data(self.hass, self.entry_id)
+        editor_key = "new_editor" if self.is_new else "editor"
+        entry_data[editor_key]["days"][self.day_key] = True
+        self.async_write_ha_state()
+
+    async def async_turn_off(self) -> None:
+        entry_data = get_entry_data(self.hass, self.entry_id)
+        editor_key = "new_editor" if self.is_new else "editor"
+        entry_data[editor_key]["days"][self.day_key] = False
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self.entry_id)},
             "name": "Enphase Envoy Cloud Control",
             "manufacturer": "Enphase Energy",
             "model": "Envoy Cloud API",

--- a/enphase_envoy_cloud_control/time.py
+++ b/enphase_envoy_cloud_control/time.py
@@ -1,0 +1,70 @@
+"""Time entities for schedule editing."""
+
+from __future__ import annotations
+
+from datetime import time
+
+from homeassistant.components.time import TimeEntity
+
+from .const import DOMAIN
+from .editor import get_entry_data
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up schedule time entities."""
+    async_add_entities(
+        [
+            EnphaseScheduleTime(entry.entry_id, "start_time", False),
+            EnphaseScheduleTime(entry.entry_id, "end_time", False),
+            EnphaseScheduleTime(entry.entry_id, "start_time", True),
+            EnphaseScheduleTime(entry.entry_id, "end_time", True),
+        ],
+        True,
+    )
+
+
+def _parse_time(value: str | None) -> time | None:
+    if not value:
+        return None
+    try:
+        return time.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+class EnphaseScheduleTime(TimeEntity):
+    """Time entity for schedule start/end."""
+
+    def __init__(self, entry_id: str, key: str, is_new: bool):
+        self.entry_id = entry_id
+        self.key = key
+        self.is_new = is_new
+        schedule_label = "New Schedule" if is_new else "Schedule"
+        label = "Start" if key == "start_time" else "End"
+        self._attr_name = f"Enphase {schedule_label} {label}"
+        suffix = "new" if is_new else "edit"
+        self._attr_unique_id = f"{entry_id}_{suffix}_{key}"
+
+    @property
+    def native_value(self) -> time | None:
+        entry_data = get_entry_data(self.hass, self.entry_id)
+        editor_key = "new_editor" if self.is_new else "editor"
+        value = entry_data[editor_key].get(self.key)
+        if isinstance(value, time):
+            return value
+        return _parse_time(value)
+
+    async def async_set_value(self, value: time) -> None:
+        entry_data = get_entry_data(self.hass, self.entry_id)
+        editor_key = "new_editor" if self.is_new else "editor"
+        entry_data[editor_key][self.key] = value.strftime("%H:%M")
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self.entry_id)},
+            "name": "Enphase Envoy Cloud Control",
+            "manufacturer": "Enphase Energy",
+            "model": "Envoy Cloud API",
+        }


### PR DESCRIPTION
### Motivation
- Provide an `update_schedule` service that follows the same Enlighten REST ordering (validate → delete → add → apply) so schedules can be edited safely from the UI while preserving existing REST compatibility. 
- Expose an in-memory editor state and normalized schedules summary to enable UI/editor entities (select/time/number/day toggles/buttons) without changing existing switches/sensors/buttons behavior.

### Description
- Added `SERVICE_UPDATE_SCHEDULE`, `UPDATE_SCHEDULE_SCHEMA`, and registered `async_update_schedule_service` which enforces confirmation and implements the required ordering: validation, delete by `schedule_id`, add new schedule, `asyncio.sleep(2)`, `set_mode(...)`, and a delayed refresh via `_schedule_post_action_refresh`.
- Extended `PLATFORMS` to include `select`, `time`, and `number` and initialized per-entry editor state under `hass.data[DOMAIN][entry.entry_id]` with `editor` and `new_editor` via `default_editor_state()` / `default_new_editor_state()`.
- Added `editor.py` providing editor state helpers and `normalize_schedules()` to produce normalized schedule summaries (`id`, `type`, `start`, `end`, `limit`, `days`).
- Added new platforms and entities: `sensor.enphase_schedules_summary` (normalized schedules), select entities (`select.enphase_schedule_selected`, `select.enphase_new_schedule_type`), time entities (`time.enphase_schedule_start/end` and `time.enphase_new_schedule_start/end`), number entities (`number.enphase_schedule_limit` / new), weekday editor switches (`switch.enphase_schedule_{mon..sun}` and `switch.enphase_new_schedule_{mon..sun}`), and action buttons (`button.enphase_schedule_save`, `button.enphase_schedule_delete`, `button.enphase_new_schedule_add`) that call the same service logic (reusing existing service handlers).
- Updated `services.yaml` to document the new `update_schedule` service and its fields and updated `sensor.py`, `button.py`, `switch.py`, and `options_flow.py` to use the new editor helpers and coordinator lookup logic while preserving existing schedule/add/delete/validate flows and ordering.

### Testing
- No automated tests were executed for this change.
- The changes were added and committed locally (files created/updated and commit recorded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983a2ba544c8325a2680dec12419700)