### PR TITLE
Add optional Enphase schedule Lovelace card, editor entities, and update_schedule service

### DIFF
--- a/custom_components/enphase_envoy_cloud_control/README.md
+++ b/custom_components/enphase_envoy_cloud_control/README.md
@@ -1,0 +1,73 @@
+# Enphase Envoy Cloud Control
+
+## Optional: Enphase Schedule Card
+
+This integration ships an optional custom Lovelace card for editing schedules using the
+integration services. The card reads schedules from
+`sensor.enphase_schedules_summary.attributes.schedules` and calls these services:
+
+- `enphase_envoy_cloud_control.add_schedule`
+- `enphase_envoy_cloud_control.update_schedule`
+- `enphase_envoy_cloud_control.delete_schedule`
+
+### Installation
+
+1. Copy the card file into your Home Assistant `www/` folder:
+   - From: `custom_components/enphase_envoy_cloud_control/www/enphase-schedule-card.js`
+   - To: `/config/www/enphase-schedule-card.js`
+2. Register the card as a Lovelace resource:
+   - **Settings → Dashboards → Resources → Add Resource**
+   - URL: `/local/enphase-schedule-card.js`
+   - Type: **JavaScript Module**
+
+### Card YAML example
+
+```yaml
+type: custom:enphase-schedule-card
+entity: sensor.enphase_schedules_summary
+domain: enphase_envoy_cloud_control
+add_service: add_schedule
+update_service: update_schedule
+delete_service: delete_schedule
+```
+
+### Requirements
+
+- The integration is installed and configured.
+- The `sensor.enphase_schedules_summary` entity exists.
+- The `add_schedule`, `update_schedule`, and `delete_schedule` services are registered.
+
+## Example: Stock entities (no custom card)
+
+You can also use the editor entities directly:
+
+```yaml
+type: entities
+title: Enphase Schedule Editor
+entities:
+  - entity: select.enphase_schedule_selected
+  - entity: select.enphase_new_schedule_type
+  - entity: time.enphase_schedule_start
+  - entity: time.enphase_schedule_end
+  - entity: number.enphase_schedule_limit
+  - entity: time.enphase_new_schedule_start
+  - entity: time.enphase_new_schedule_end
+  - entity: number.enphase_new_schedule_limit
+  - entity: switch.enphase_schedule_mon
+  - entity: switch.enphase_schedule_tue
+  - entity: switch.enphase_schedule_wed
+  - entity: switch.enphase_schedule_thu
+  - entity: switch.enphase_schedule_fri
+  - entity: switch.enphase_schedule_sat
+  - entity: switch.enphase_schedule_sun
+  - entity: switch.enphase_new_schedule_mon
+  - entity: switch.enphase_new_schedule_tue
+  - entity: switch.enphase_new_schedule_wed
+  - entity: switch.enphase_new_schedule_thu
+  - entity: switch.enphase_new_schedule_fri
+  - entity: switch.enphase_new_schedule_sat
+  - entity: switch.enphase_new_schedule_sun
+  - entity: button.enphase_schedule_save
+  - entity: button.enphase_schedule_delete
+  - entity: button.enphase_new_schedule_add
+```

--- a/custom_components/enphase_envoy_cloud_control/www/enphase-schedule-card.js
+++ b/custom_components/enphase_envoy_cloud_control/www/enphase-schedule-card.js
@@ -1,0 +1,412 @@
+/* eslint-disable class-methods-use-this */
+class EnphaseScheduleCard extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._config = null;
+    this._hass = null;
+    this._state = {
+      selectedId: null,
+      edit: this._emptySchedule("cfg"),
+      add: this._emptySchedule("cfg"),
+      error: "",
+    };
+  }
+
+  setConfig(config) {
+    if (!config || !config.entity) {
+      throw new Error("Entity is required");
+    }
+    this._config = {
+      domain: "enphase_envoy_cloud_control",
+      add_service: "add_schedule",
+      update_service: "update_schedule",
+      delete_service: "delete_schedule",
+      ...config,
+    };
+    this._render();
+  }
+
+  set hass(hass) {
+    this._hass = hass;
+    this._render();
+  }
+
+  getCardSize() {
+    return 4;
+  }
+
+  _emptySchedule(defaultType) {
+    return {
+      schedule_type: defaultType || "cfg",
+      start_time: "00:00",
+      end_time: "00:00",
+      limit: 0,
+      days: [],
+    };
+  }
+
+  _daysLabel(days) {
+    const names = {
+      1: "Mon",
+      2: "Tue",
+      3: "Wed",
+      4: "Thu",
+      5: "Fri",
+      6: "Sat",
+      7: "Sun",
+    };
+    return days.map((day) => names[day] || day).join(" ");
+  }
+
+  _validate(schedule) {
+    if (schedule.start_time === schedule.end_time) {
+      return "Start time and end time must differ.";
+    }
+    if (!Array.isArray(schedule.days) || schedule.days.length === 0) {
+      return "Select at least one day.";
+    }
+    const limit = Number(schedule.limit);
+    if (Number.isNaN(limit) || limit < 0 || limit > 100) {
+      return "Limit must be between 0 and 100.";
+    }
+    return "";
+  }
+
+  _serviceCall(service, data) {
+    if (!this._hass) {
+      return;
+    }
+    this._hass.callService(this._config.domain, service, data);
+  }
+
+  _onSelectSchedule(id) {
+    const schedules = this._getSchedules();
+    const selected = schedules.find((sched) => sched.id === id);
+    if (!selected) {
+      return;
+    }
+    this._state.selectedId = id;
+    this._state.edit = {
+      schedule_type: selected.type,
+      start_time: selected.start,
+      end_time: selected.end,
+      limit: selected.limit,
+      days: [...selected.days],
+    };
+    this._state.error = "";
+    this._render();
+  }
+
+  _toggleDay(target, day) {
+    const idx = target.days.indexOf(day);
+    if (idx >= 0) {
+      target.days.splice(idx, 1);
+    } else {
+      target.days.push(day);
+      target.days.sort((a, b) => a - b);
+    }
+  }
+
+  _handleSave() {
+    const error = this._validate(this._state.edit);
+    if (error) {
+      this._state.error = error;
+      this._render();
+      return;
+    }
+    if (!this._state.selectedId) {
+      this._state.error = "Select a schedule to update.";
+      this._render();
+      return;
+    }
+    this._state.error = "";
+    this._serviceCall(this._config.update_service, {
+      schedule_id: this._state.selectedId,
+      schedule_type: this._state.edit.schedule_type,
+      start_time: this._state.edit.start_time,
+      end_time: this._state.edit.end_time,
+      limit: Number(this._state.edit.limit),
+      days: this._state.edit.days,
+      confirm: true,
+    });
+  }
+
+  _handleDelete() {
+    if (!this._state.selectedId) {
+      this._state.error = "Select a schedule to delete.";
+      this._render();
+      return;
+    }
+    this._state.error = "";
+    this._serviceCall(this._config.delete_service, {
+      schedule_id: this._state.selectedId,
+      confirm: true,
+    });
+  }
+
+  _handleAdd() {
+    const error = this._validate(this._state.add);
+    if (error) {
+      this._state.error = error;
+      this._render();
+      return;
+    }
+    this._state.error = "";
+    this._serviceCall(this._config.add_service, {
+      schedule_type: this._state.add.schedule_type,
+      start_time: this._state.add.start_time,
+      end_time: this._state.add.end_time,
+      limit: Number(this._state.add.limit),
+      days: this._state.add.days,
+    });
+  }
+
+  _getSchedules() {
+    if (!this._hass || !this._config) {
+      return [];
+    }
+    const entity = this._hass.states[this._config.entity];
+    if (!entity || !entity.attributes || !Array.isArray(entity.attributes.schedules)) {
+      return [];
+    }
+    return entity.attributes.schedules;
+  }
+
+  _render() {
+    if (!this.shadowRoot || !this._config) {
+      return;
+    }
+    const schedules = this._getSchedules();
+    const edit = this._state.edit;
+    const add = this._state.add;
+    const error = this._state.error;
+
+    this.shadowRoot.innerHTML = `
+      <ha-card header="Enphase Schedules">
+        <div class="card-content">
+          <div class="section">
+            <div class="section-title">Schedules</div>
+            <div class="schedule-list">
+              ${schedules
+                .map(
+                  (sched) => `
+                    <button class="schedule-row ${this._state.selectedId === sched.id ? "selected" : ""}" data-id="${sched.id}">
+                      <span class="type">${sched.type.toUpperCase()}</span>
+                      <span class="time">${sched.start}–${sched.end}</span>
+                      <span class="limit">${sched.limit}%</span>
+                      <span class="days">${this._daysLabel(sched.days)}</span>
+                    </button>
+                  `
+                )
+                .join("")}
+            </div>
+          </div>
+
+          <div class="section">
+            <div class="section-title">Edit selected</div>
+            <div class="row">
+              <label>Type</label>
+              <select class="edit-type">
+                ${["cfg", "dtg", "rbd"]
+                  .map(
+                    (type) =>
+                      `<option value="${type}" ${edit.schedule_type === type ? "selected" : ""}>${type.toUpperCase()}</option>`
+                  )
+                  .join("")}
+              </select>
+            </div>
+            <div class="row">
+              <label>Start</label>
+              <input class="edit-start" type="time" value="${edit.start_time}" />
+              <label>End</label>
+              <input class="edit-end" type="time" value="${edit.end_time}" />
+            </div>
+            <div class="row">
+              <label>Limit</label>
+              <input class="edit-limit" type="number" min="0" max="100" value="${edit.limit}" />
+            </div>
+            <div class="row days">
+              ${[1, 2, 3, 4, 5, 6, 7]
+                .map(
+                  (day) => `
+                    <button class="day-chip ${edit.days.includes(day) ? "active" : ""}" data-day="${day}" data-target="edit">
+                      ${this._daysLabel([day])}
+                    </button>
+                  `
+                )
+                .join("")}
+            </div>
+            <div class="row actions">
+              <button class="primary save-btn">Save</button>
+              <button class="secondary delete-btn">Delete</button>
+            </div>
+          </div>
+
+          <div class="section">
+            <div class="section-title">Add new schedule</div>
+            <div class="row">
+              <label>Type</label>
+              <select class="add-type">
+                ${["cfg", "dtg", "rbd"]
+                  .map(
+                    (type) =>
+                      `<option value="${type}" ${add.schedule_type === type ? "selected" : ""}>${type.toUpperCase()}</option>`
+                  )
+                  .join("")}
+              </select>
+            </div>
+            <div class="row">
+              <label>Start</label>
+              <input class="add-start" type="time" value="${add.start_time}" />
+              <label>End</label>
+              <input class="add-end" type="time" value="${add.end_time}" />
+            </div>
+            <div class="row">
+              <label>Limit</label>
+              <input class="add-limit" type="number" min="0" max="100" value="${add.limit}" />
+            </div>
+            <div class="row days">
+              ${[1, 2, 3, 4, 5, 6, 7]
+                .map(
+                  (day) => `
+                    <button class="day-chip ${add.days.includes(day) ? "active" : ""}" data-day="${day}" data-target="add">
+                      ${this._daysLabel([day])}
+                    </button>
+                  `
+                )
+                .join("")}
+            </div>
+            <div class="row actions">
+              <button class="primary add-btn">Add schedule</button>
+            </div>
+          </div>
+
+          ${error ? `<div class="error">${error}</div>` : ""}
+        </div>
+      </ha-card>
+      <style>
+        .card-content {
+          display: flex;
+          flex-direction: column;
+          gap: 16px;
+        }
+        .section-title {
+          font-weight: 600;
+          margin-bottom: 8px;
+        }
+        .schedule-list {
+          display: flex;
+          flex-direction: column;
+          gap: 8px;
+        }
+        .schedule-row {
+          display: grid;
+          grid-template-columns: auto auto auto 1fr;
+          gap: 8px;
+          padding: 8px;
+          border: 1px solid var(--divider-color);
+          background: var(--card-background-color);
+          cursor: pointer;
+          text-align: left;
+        }
+        .schedule-row.selected {
+          border-color: var(--primary-color);
+        }
+        .row {
+          display: flex;
+          flex-wrap: wrap;
+          align-items: center;
+          gap: 8px;
+        }
+        .row label {
+          min-width: 48px;
+          font-size: 0.9em;
+        }
+        .days {
+          gap: 6px;
+        }
+        .day-chip {
+          border: 1px solid var(--divider-color);
+          background: var(--card-background-color);
+          padding: 4px 8px;
+          cursor: pointer;
+        }
+        .day-chip.active {
+          background: var(--primary-color);
+          color: var(--text-primary-color);
+          border-color: var(--primary-color);
+        }
+        .actions {
+          gap: 12px;
+        }
+        button.primary {
+          background: var(--primary-color);
+          color: var(--text-primary-color);
+          border: none;
+          padding: 6px 12px;
+          cursor: pointer;
+        }
+        button.secondary {
+          background: var(--card-background-color);
+          color: var(--primary-text-color);
+          border: 1px solid var(--divider-color);
+          padding: 6px 12px;
+          cursor: pointer;
+        }
+        .error {
+          color: var(--error-color);
+          font-weight: 500;
+        }
+      </style>
+    `;
+
+    this.shadowRoot.querySelectorAll(".schedule-row").forEach((row) => {
+      row.addEventListener("click", (event) => {
+        const id = event.currentTarget.getAttribute("data-id");
+        this._onSelectSchedule(id);
+      });
+    });
+    this.shadowRoot.querySelector(".edit-type")?.addEventListener("change", (event) => {
+      edit.schedule_type = event.target.value;
+    });
+    this.shadowRoot.querySelector(".edit-start")?.addEventListener("change", (event) => {
+      edit.start_time = event.target.value;
+    });
+    this.shadowRoot.querySelector(".edit-end")?.addEventListener("change", (event) => {
+      edit.end_time = event.target.value;
+    });
+    this.shadowRoot.querySelector(".edit-limit")?.addEventListener("change", (event) => {
+      edit.limit = Number(event.target.value);
+    });
+    this.shadowRoot.querySelector(".add-type")?.addEventListener("change", (event) => {
+      add.schedule_type = event.target.value;
+    });
+    this.shadowRoot.querySelector(".add-start")?.addEventListener("change", (event) => {
+      add.start_time = event.target.value;
+    });
+    this.shadowRoot.querySelector(".add-end")?.addEventListener("change", (event) => {
+      add.end_time = event.target.value;
+    });
+    this.shadowRoot.querySelector(".add-limit")?.addEventListener("change", (event) => {
+      add.limit = Number(event.target.value);
+    });
+    this.shadowRoot.querySelectorAll(".day-chip").forEach((chip) => {
+      chip.addEventListener("click", (event) => {
+        const day = Number(event.currentTarget.getAttribute("data-day"));
+        const target = event.currentTarget.getAttribute("data-target");
+        if (target === "edit") {
+          this._toggleDay(edit, day);
+        } else {
+          this._toggleDay(add, day);
+        }
+        this._render();
+      });
+    });
+    this.shadowRoot.querySelector(".save-btn")?.addEventListener("click", () => this._handleSave());
+    this.shadowRoot.querySelector(".delete-btn")?.addEventListener("click", () => this._handleDelete());
+    this.shadowRoot.querySelector(".add-btn")?.addEventListener("click", () => this._handleAdd());
+  }
+}
+
+customElements.define("enphase-schedule-card", EnphaseScheduleCard);

--- a/enphase_envoy_cloud_control/editor.py
+++ b/enphase_envoy_cloud_control/editor.py
@@ -1,0 +1,168 @@
+"""Helpers for schedule editor state and normalization."""
+
+from __future__ import annotations
+
+import re
+from datetime import time
+from typing import Any
+
+from .const import DOMAIN
+from .coordinator import EnphaseCoordinator
+
+DAY_ORDER: list[tuple[str, int]] = [
+    ("mon", 1),
+    ("tue", 2),
+    ("wed", 3),
+    ("thu", 4),
+    ("fri", 5),
+    ("sat", 6),
+    ("sun", 7),
+]
+DAY_KEY_BY_INDEX = {index: key for key, index in DAY_ORDER}
+
+
+def default_day_flags() -> dict[str, bool]:
+    """Return day flag defaults (all false)."""
+    return {key: False for key, _ in DAY_ORDER}
+
+
+def default_editor_state() -> dict[str, Any]:
+    """Return a fresh editor state mapping."""
+    return {
+        "selected_schedule_id": None,
+        "schedule_type": "cfg",
+        "start_time": "00:00",
+        "end_time": "00:00",
+        "limit": 0,
+        "days": default_day_flags(),
+    }
+
+
+def default_new_editor_state() -> dict[str, Any]:
+    """Return default state for new schedules."""
+    return {
+        "schedule_type": "cfg",
+        "start_time": "00:00",
+        "end_time": "00:00",
+        "limit": 0,
+        "days": default_day_flags(),
+    }
+
+
+def get_entry_data(hass, entry_id: str) -> dict[str, Any]:
+    """Return stored entry data."""
+    return hass.data[DOMAIN][entry_id]
+
+
+def get_coordinator(hass, entry_id: str) -> EnphaseCoordinator:
+    """Return coordinator from entry data."""
+    return get_entry_data(hass, entry_id)["coordinator"]
+
+
+def editor_days_from_list(days: list[int]) -> dict[str, bool]:
+    """Convert list of ints into editor day flags."""
+    flags = default_day_flags()
+    for day in days:
+        key = DAY_KEY_BY_INDEX.get(day)
+        if key:
+            flags[key] = True
+    return flags
+
+
+def days_list_from_editor(flags: dict[str, bool]) -> list[int]:
+    """Convert editor day flags into list of ints."""
+    return [index for key, index in DAY_ORDER if flags.get(key)]
+
+
+def _normalize_time(value: Any) -> str:
+    if isinstance(value, time):
+        return value.strftime("%H:%M")
+    if value is None:
+        return "00:00"
+    if isinstance(value, (int, float)):
+        return f"{int(value):02d}:00"
+    value_str = str(value)
+    match = re.search(r"(\d{2}:\d{2})", value_str)
+    if match:
+        return match.group(1)
+    return value_str[:5]
+
+
+def _normalize_days(raw: Any) -> list[int]:
+    if not raw:
+        return []
+    if isinstance(raw, dict):
+        return sorted(
+            int(key)
+            for key, enabled in raw.items()
+            if enabled and str(key).isdigit()
+        )
+    if isinstance(raw, (list, tuple, set)):
+        values = list(raw)
+    else:
+        values = re.split(r"[,\s]+", str(raw))
+    days: list[int] = []
+    for value in values:
+        try:
+            day = int(value)
+        except (TypeError, ValueError):
+            continue
+        if 1 <= day <= 7:
+            days.append(day)
+    return sorted(set(days))
+
+
+def _collect_schedules(coordinator: EnphaseCoordinator, mode: str) -> list[dict[str, Any]]:
+    data_root = coordinator.data or {}
+    schedule_block = data_root.get("data", {}).get(f"{mode}Control", {})
+    schedules = schedule_block.get("schedules")
+    if isinstance(schedules, list):
+        return schedules
+
+    fallback = data_root.get("schedules", {})
+    if isinstance(fallback, dict):
+        candidate = fallback.get(mode)
+        if isinstance(candidate, dict) and isinstance(candidate.get("details"), list):
+            return candidate["details"]
+        if isinstance(candidate, list):
+            return candidate
+        inner = fallback.get("data", {}).get(mode)
+        if isinstance(inner, dict) and isinstance(inner.get("details"), list):
+            return inner["details"]
+        if isinstance(inner, list):
+            return inner
+
+    cached = getattr(coordinator.client, "_last_schedules", None)
+    if isinstance(cached, dict):
+        candidate = cached.get(mode)
+        if isinstance(candidate, dict) and isinstance(candidate.get("details"), list):
+            return candidate["details"]
+        if isinstance(candidate, list):
+            return candidate
+
+    return []
+
+
+def normalize_schedules(coordinator: EnphaseCoordinator) -> list[dict[str, Any]]:
+    """Return normalized schedules for all modes."""
+    normalized: list[dict[str, Any]] = []
+    for mode in ("cfg", "dtg", "rbd"):
+        for schedule in _collect_schedules(coordinator, mode):
+            schedule_id = schedule.get("scheduleId")
+            if schedule_id is None:
+                continue
+            normalized.append(
+                {
+                    "id": str(schedule_id),
+                    "type": str(schedule.get("scheduleType", mode)).lower(),
+                    "start": _normalize_time(schedule.get("startTime")),
+                    "end": _normalize_time(schedule.get("endTime")),
+                    "limit": int(schedule.get("limit") or schedule.get("powerLimit") or 0),
+                    "days": _normalize_days(
+                        schedule.get("days")
+                        or schedule.get("daysOfWeek")
+                        or schedule.get("dayOfWeek")
+                    ),
+                }
+            )
+    return normalized

--- a/enphase_envoy_cloud_control/number.py
+++ b/enphase_envoy_cloud_control/number.py
@@ -1,0 +1,57 @@
+"""Number entities for schedule editing."""
+
+from __future__ import annotations
+
+from homeassistant.components.number import NumberEntity
+
+from .const import DOMAIN
+from .editor import get_entry_data
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up schedule number entities."""
+    async_add_entities(
+        [
+            EnphaseScheduleLimit(entry.entry_id, False),
+            EnphaseScheduleLimit(entry.entry_id, True),
+        ],
+        True,
+    )
+
+
+class EnphaseScheduleLimit(NumberEntity):
+    """Number entity for schedule limit."""
+
+    _attr_native_min_value = 0
+    _attr_native_max_value = 100
+    _attr_native_step = 1
+    _attr_native_unit_of_measurement = "%"
+
+    def __init__(self, entry_id: str, is_new: bool):
+        self.entry_id = entry_id
+        self.is_new = is_new
+        schedule_label = "New Schedule" if is_new else "Schedule"
+        self._attr_name = f"Enphase {schedule_label} Limit"
+        suffix = "new" if is_new else "edit"
+        self._attr_unique_id = f"{entry_id}_{suffix}_limit"
+
+    @property
+    def native_value(self) -> float | None:
+        entry_data = get_entry_data(self.hass, self.entry_id)
+        editor_key = "new_editor" if self.is_new else "editor"
+        return float(entry_data[editor_key].get("limit", 0))
+
+    async def async_set_native_value(self, value: float) -> None:
+        entry_data = get_entry_data(self.hass, self.entry_id)
+        editor_key = "new_editor" if self.is_new else "editor"
+        entry_data[editor_key]["limit"] = int(value)
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self.entry_id)},
+            "name": "Enphase Envoy Cloud Control",
+            "manufacturer": "Enphase Energy",
+            "model": "Envoy Cloud API",
+        }

--- a/enphase_envoy_cloud_control/options_flow.py
+++ b/enphase_envoy_cloud_control/options_flow.py
@@ -218,7 +218,8 @@ class EnphaseOptionsFlowHandler(config_entries.OptionsFlow):
 
     def _schedule_options(self) -> list[selector.SelectOptionDict]:
         """Build schedule options for the delete form."""
-        coordinator = self.hass.data.get(DOMAIN, {}).get(self._config_entry.entry_id)
+        entry_data = self.hass.data.get(DOMAIN, {}).get(self._config_entry.entry_id)
+        coordinator = entry_data.get("coordinator") if isinstance(entry_data, dict) else None
         if not coordinator or not getattr(coordinator, "data", None):
             return []
 

--- a/enphase_envoy_cloud_control/select.py
+++ b/enphase_envoy_cloud_control/select.py
@@ -1,0 +1,112 @@
+"""Select entities for schedule editing."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.select import SelectEntity
+
+from .const import DOMAIN
+from .editor import (
+    editor_days_from_list,
+    get_coordinator,
+    get_entry_data,
+    normalize_schedules,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up schedule select entities."""
+    coordinator = get_coordinator(hass, entry.entry_id)
+    async_add_entities(
+        [
+            EnphaseScheduleSelect(coordinator, entry.entry_id),
+            EnphaseNewScheduleTypeSelect(entry.entry_id),
+        ],
+        True,
+    )
+
+
+class EnphaseScheduleSelect(SelectEntity):
+    """Select the active schedule to edit."""
+
+    _attr_name = "Enphase Schedule Selected"
+    _attr_icon = "mdi:calendar-edit"
+
+    def __init__(self, coordinator, entry_id: str):
+        self.coordinator = coordinator
+        self.entry_id = entry_id
+        self._attr_unique_id = f"{entry_id}_schedule_selected"
+
+    @property
+    def options(self):
+        schedules = normalize_schedules(self.coordinator)
+        return [schedule["id"] for schedule in schedules]
+
+    @property
+    def current_option(self):
+        editor = get_entry_data(self.hass, self.entry_id)["editor"]
+        return editor.get("selected_schedule_id")
+
+    async def async_select_option(self, option: str) -> None:
+        entry_data = get_entry_data(self.hass, self.entry_id)
+        schedules = normalize_schedules(self.coordinator)
+        match = next((sched for sched in schedules if sched["id"] == option), None)
+        editor = entry_data["editor"]
+        editor["selected_schedule_id"] = option
+        if match:
+            editor["schedule_type"] = match.get("type", "cfg")
+            editor["start_time"] = match.get("start", "00:00")
+            editor["end_time"] = match.get("end", "00:00")
+            editor["limit"] = int(match.get("limit", 0))
+            editor["days"] = editor_days_from_list(match.get("days", []))
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self.entry_id)},
+            "name": "Enphase Envoy Cloud Control",
+            "manufacturer": "Enphase Energy",
+            "model": "Envoy Cloud API",
+        }
+
+
+class EnphaseNewScheduleTypeSelect(SelectEntity):
+    """Select schedule type for a new schedule."""
+
+    _attr_name = "Enphase New Schedule Type"
+    _attr_icon = "mdi:calendar-plus"
+
+    def __init__(self, entry_id: str):
+        self.entry_id = entry_id
+        self._attr_unique_id = f"{entry_id}_new_schedule_type"
+        self._attr_options = ["cfg", "dtg", "rbd"]
+
+    @property
+    def options(self):
+        return list(self._attr_options)
+
+    @property
+    def current_option(self):
+        entry_data = get_entry_data(self.hass, self.entry_id)
+        return entry_data["new_editor"].get("schedule_type", "cfg")
+
+    async def async_select_option(self, option: str) -> None:
+        if option not in self._attr_options:
+            _LOGGER.warning("[Enphase] Invalid schedule type selected: %s", option)
+            return
+        entry_data = get_entry_data(self.hass, self.entry_id)
+        entry_data["new_editor"]["schedule_type"] = option
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self.entry_id)},
+            "name": "Enphase Envoy Cloud Control",
+            "manufacturer": "Enphase Energy",
+            "model": "Envoy Cloud API",
+        }

--- a/enphase_envoy_cloud_control/sensor.py
+++ b/enphase_envoy_cloud_control/sensor.py
@@ -5,14 +5,15 @@ from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers.entity import EntityCategory
 from .const import DOMAIN
+from .editor import normalize_schedules, get_coordinator
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up Enphase sensors from a config entry."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]
-    sensors = [EnphaseBatteryModesSensor(coordinator)]
+    coordinator = get_coordinator(hass, entry.entry_id)
+    sensors = [EnphaseBatteryModesSensor(coordinator), EnphaseSchedulesSummarySensor(coordinator)]
 
     # Add per-mode schedule sensors
     for mode in ["cfg", "dtg", "rbd"]:
@@ -94,6 +95,44 @@ class EnphaseBatteryModesSensor(CoordinatorEntity, SensorEntity):
     @property
     def device_info(self):
         """Ensure the sensor is attached to the shared Enphase device."""
+        return {
+            "identifiers": {(DOMAIN, self.coordinator.entry.entry_id)},
+            "name": "Enphase Envoy Cloud Control",
+            "manufacturer": "Enphase Energy",
+            "model": "Envoy Cloud API",
+        }
+
+
+class EnphaseSchedulesSummarySensor(CoordinatorEntity, SensorEntity):
+    """Normalized schedule list for editor usage."""
+
+    _attr_name = "Enphase Schedules Summary"
+    _attr_icon = "mdi:calendar-multiple"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator):
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.entry.entry_id}_schedules_summary"
+
+    @property
+    def state(self):
+        schedules = normalize_schedules(self.coordinator)
+        return str(len(schedules))
+
+    @property
+    def extra_state_attributes(self):
+        attrs = {
+            "schedules": normalize_schedules(self.coordinator),
+            "last_refresh": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S%z"),
+        }
+        if getattr(self.coordinator, "last_update_success_time", None):
+            t = self.coordinator.last_update_success_time
+            if isinstance(t, datetime):
+                attrs["last_successful_poll"] = t.strftime("%Y-%m-%dT%H:%M:%S%z")
+        return attrs
+
+    @property
+    def device_info(self):
         return {
             "identifiers": {(DOMAIN, self.coordinator.entry.entry_id)},
             "name": "Enphase Envoy Cloud Control",

--- a/enphase_envoy_cloud_control/services.yaml
+++ b/enphase_envoy_cloud_control/services.yaml
@@ -66,6 +66,82 @@ add_schedule:
             - label: "Sunday"
               value: "7"
 
+update_schedule:
+  name: "Update Schedule"
+  description: "Update an existing Enphase battery schedule via the Cloud API."
+  fields:
+    schedule_id:
+      name: "Schedule ID"
+      description: "Schedule ID to update."
+      required: true
+      selector:
+        text:
+    schedule_type:
+      name: "Schedule Type"
+      description: "Choose which mode to schedule"
+      required: true
+      selector:
+        select:
+          options:
+            - label: "Charge from Grid (CFG)"
+              value: "cfg"
+            - label: "Discharge to Grid (DTG)"
+              value: "dtg"
+            - label: "Restrict Battery Discharge (RBD)"
+              value: "rbd"
+    start_time:
+      name: "Start Time"
+      description: "Time the schedule starts (HH:MM)"
+      required: true
+      selector:
+        time:
+    end_time:
+      name: "End Time"
+      description: "Time the schedule ends (HH:MM)"
+      required: true
+      selector:
+        time:
+    limit:
+      name: "Limit"
+      description: "Battery power limit for this schedule (percentage)"
+      required: true
+      example: 80
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          mode: box
+          unit_of_measurement: "%"
+    days:
+      name: "Days of Week"
+      description: "Select days this schedule applies (1=Monday ... 7=Sunday)"
+      required: true
+      selector:
+        select:
+          multiple: true
+          options:
+            - label: "Monday"
+              value: "1"
+            - label: "Tuesday"
+              value: "2"
+            - label: "Wednesday"
+              value: "3"
+            - label: "Thursday"
+              value: "4"
+            - label: "Friday"
+              value: "5"
+            - label: "Saturday"
+              value: "6"
+            - label: "Sunday"
+              value: "7"
+    confirm:
+      name: "Confirm update"
+      description: "Enable to confirm this schedule should be updated."
+      required: true
+      selector:
+        boolean:
+
 delete_schedule:
   name: "Delete Schedule"
   description: "Remove an existing Enphase schedule using its scheduleId."

--- a/enphase_envoy_cloud_control/switch.py
+++ b/enphase_envoy_cloud_control/switch.py
@@ -4,18 +4,27 @@ import logging
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
+from .editor import DAY_ORDER, get_coordinator, get_entry_data
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
-    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = get_coordinator(hass, entry.entry_id)
     data = coordinator.data.get("data", {}) if coordinator.data else {}
     switches = []
 
     for key in ["cfgControl", "dtgControl", "rbdControl"]:
         if key in data:
             switches.append(EnphaseModeSwitch(coordinator, key))
+
+    for key, _ in DAY_ORDER:
+        switches.append(
+            EnphaseEditorDaySwitch(entry.entry_id, key, is_new=False)
+        )
+        switches.append(
+            EnphaseEditorDaySwitch(entry.entry_id, key, is_new=True)
+        )
 
     async_add_entities(switches, True)
 
@@ -66,6 +75,46 @@ class EnphaseModeSwitch(CoordinatorEntity, SwitchEntity):
         """Attach to Enphase Envoy Cloud device."""
         return {
             "identifiers": {(DOMAIN, self.coordinator.entry.entry_id)},
+            "name": "Enphase Envoy Cloud Control",
+            "manufacturer": "Enphase Energy",
+            "model": "Envoy Cloud API",
+        }
+
+
+class EnphaseEditorDaySwitch(SwitchEntity):
+    """Switch representing a weekday toggle for schedule editing."""
+
+    def __init__(self, entry_id: str, day_key: str, is_new: bool):
+        self.entry_id = entry_id
+        self.day_key = day_key
+        self.is_new = is_new
+        schedule_label = "New Schedule" if is_new else "Schedule"
+        self._attr_name = f"Enphase {schedule_label} {day_key.title()}"
+        suffix = "new" if is_new else "edit"
+        self._attr_unique_id = f"{entry_id}_{suffix}_{day_key}"
+
+    @property
+    def is_on(self) -> bool:
+        entry_data = get_entry_data(self.hass, self.entry_id)
+        editor_key = "new_editor" if self.is_new else "editor"
+        return bool(entry_data[editor_key]["days"].get(self.day_key))
+
+    async def async_turn_on(self) -> None:
+        entry_data = get_entry_data(self.hass, self.entry_id)
+        editor_key = "new_editor" if self.is_new else "editor"
+        entry_data[editor_key]["days"][self.day_key] = True
+        self.async_write_ha_state()
+
+    async def async_turn_off(self) -> None:
+        entry_data = get_entry_data(self.hass, self.entry_id)
+        editor_key = "new_editor" if self.is_new else "editor"
+        entry_data[editor_key]["days"][self.day_key] = False
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self.entry_id)},
             "name": "Enphase Envoy Cloud Control",
             "manufacturer": "Enphase Energy",
             "model": "Envoy Cloud API",

--- a/enphase_envoy_cloud_control/time.py
+++ b/enphase_envoy_cloud_control/time.py
@@ -1,0 +1,70 @@
+"""Time entities for schedule editing."""
+
+from __future__ import annotations
+
+from datetime import time
+
+from homeassistant.components.time import TimeEntity
+
+from .const import DOMAIN
+from .editor import get_entry_data
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up schedule time entities."""
+    async_add_entities(
+        [
+            EnphaseScheduleTime(entry.entry_id, "start_time", False),
+            EnphaseScheduleTime(entry.entry_id, "end_time", False),
+            EnphaseScheduleTime(entry.entry_id, "start_time", True),
+            EnphaseScheduleTime(entry.entry_id, "end_time", True),
+        ],
+        True,
+    )
+
+
+def _parse_time(value: str | None) -> time | None:
+    if not value:
+        return None
+    try:
+        return time.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+class EnphaseScheduleTime(TimeEntity):
+    """Time entity for schedule start/end."""
+
+    def __init__(self, entry_id: str, key: str, is_new: bool):
+        self.entry_id = entry_id
+        self.key = key
+        self.is_new = is_new
+        schedule_label = "New Schedule" if is_new else "Schedule"
+        label = "Start" if key == "start_time" else "End"
+        self._attr_name = f"Enphase {schedule_label} {label}"
+        suffix = "new" if is_new else "edit"
+        self._attr_unique_id = f"{entry_id}_{suffix}_{key}"
+
+    @property
+    def native_value(self) -> time | None:
+        entry_data = get_entry_data(self.hass, self.entry_id)
+        editor_key = "new_editor" if self.is_new else "editor"
+        value = entry_data[editor_key].get(self.key)
+        if isinstance(value, time):
+            return value
+        return _parse_time(value)
+
+    async def async_set_value(self, value: time) -> None:
+        entry_data = get_entry_data(self.hass, self.entry_id)
+        editor_key = "new_editor" if self.is_new else "editor"
+        entry_data[editor_key][self.key] = value.strftime("%H:%M")
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self.entry_id)},
+            "name": "Enphase Envoy Cloud Control",
+            "manufacturer": "Enphase Energy",
+            "model": "Envoy Cloud API",
+        }


### PR DESCRIPTION
### Motivation
- Provide a simple, dependency-free Lovelace editor card for schedules that uses the integration services and preserves existing service formats and ordering. 
- Expose an in-memory editor state and normalized schedule summary so UIs (card or native entities) can edit/add/delete schedules without changing current automation/service behavior.

### Description
- Add a dependency-free frontend card at `custom_components/enphase_envoy_cloud_control/www/enphase-schedule-card.js` that reads `sensor.enphase_schedules_summary.attributes.schedules`, validates inputs client-side, and calls the integration services `add_schedule`, `delete_schedule`, and `update_schedule` with numeric day values only. 
- Add README documentation `custom_components/enphase_envoy_cloud_control/README.md` with installation steps, resource registration, and YAML examples for the custom card and the stock-entities approach. 
- Add editor support and normalization helpers in `enphase_envoy_cloud_control/editor.py`, wire per-entry editor state into `hass.data[DOMAIN][entry.entry_id]`, and add a normalized `sensor.enphase_schedules_summary` in `sensor.py`. 
- Register new platforms and entities to back the editor UI: `select` (`select.enphase_schedule_selected`, `select.enphase_new_schedule_type`), `time` (`time.enphase_schedule_start/end`, `time.enphase_new_schedule_start/end`), `number` (`number.enphase_schedule_limit` / new), weekday editor `switch`es, and `button` entities to `Save`, `Delete`, and `Add` which call the integration services; and add the `update_schedule` service and `UPDATE_SCHEDULE_SCHEMA` implementing validation → delete → add → apply ordering.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983a2ba544c8325a2680dec12419700)