### PR TITLE
Make notifications optional

### DIFF
--- a/custom_components/enphase_envoy_cloud_control/__init__.py
+++ b/custom_components/enphase_envoy_cloud_control/__init__.py
@@ -306,15 +306,20 @@ def _register_services(hass: HomeAssistant) -> None:
             ) from exc
 
         if "persistent_notification" in hass.config.components:
-            persistent_notification.async_create(
-                hass,
-            (
-                "✅ Schedule added successfully for "
-                f"{schedule_type.upper()} ({start_str}–{end_str})."
-            ),
-            title="Enphase Envoy Cloud Control",
-            notification_id=f"{DOMAIN}_schedule_add",
+            # Check if notifications are enabled in options
+            notifications_enabled = coordinator.entry.options.get(
+                "notifications_enabled", True
             )
+            if notifications_enabled:
+                persistent_notification.async_create(
+                    hass,
+                (
+                    "✅ Schedule added successfully for "
+                    f"{schedule_type.upper()} ({start_str}–{end_str})."
+                ),
+                title="Enphase Envoy Cloud Control",
+                notification_id=f"{DOMAIN}_schedule_add",
+                )
 
         async_call_later(
             hass,
@@ -512,12 +517,17 @@ def _register_services(hass: HomeAssistant) -> None:
                 ) from exc
 
         if "persistent_notification" in hass.config.components:
-            persistent_notification.async_create(
-                hass,
-                f"🗑️ Schedule(s) deleted successfully: {', '.join(schedule_ids)}.",
-                title="Enphase Envoy Cloud Control",
-                notification_id=f"{DOMAIN}_schedule_delete",
+            # Check if notifications are enabled in options
+            notifications_enabled = coordinator.entry.options.get(
+                "notifications_enabled", True
             )
+            if notifications_enabled:
+                persistent_notification.async_create(
+                    hass,
+                    f"🗑️ Schedule(s) deleted successfully: {', '.join(schedule_ids)}.",
+                    title="Enphase Envoy Cloud Control",
+                    notification_id=f"{DOMAIN}_schedule_delete",
+                )
 
         async_call_later(
             hass,
@@ -549,12 +559,17 @@ def _register_services(hass: HomeAssistant) -> None:
                 message = f"✅ Schedule valid: {detail}"
 
         if "persistent_notification" in hass.config.components:
-            persistent_notification.async_create(
-                hass,
-                message,
-                title="Enphase Envoy Cloud Control",
-                notification_id=f"{DOMAIN}_schedule_validate",
+            # Check if notifications are enabled in options
+            notifications_enabled = coordinator.entry.options.get(
+                "notifications_enabled", True
             )
+            if notifications_enabled:
+                persistent_notification.async_create(
+                    hass,
+                    message,
+                    title="Enphase Envoy Cloud Control",
+                    notification_id=f"{DOMAIN}_schedule_validate",
+                )
 
     hass.services.async_register(
         DOMAIN,

--- a/custom_components/enphase_envoy_cloud_control/options_flow.py
+++ b/custom_components/enphase_envoy_cloud_control/options_flow.py
@@ -44,6 +44,12 @@ class EnphaseOptionsFlowHandler(config_entries.OptionsFlow):
                         "poll_interval", DEFAULT_POLL_INTERVAL
                     ),
                 ): int,
+                vol.Optional(
+                    "notifications_enabled",
+                    default=self._config_entry.options.get(
+                        "notifications_enabled", True
+                    ),
+                ): bool,
             }
         )
 

--- a/custom_components/enphase_envoy_cloud_control/switch.py
+++ b/custom_components/enphase_envoy_cloud_control/switch.py
@@ -27,6 +27,9 @@ async def async_setup_entry(hass, entry, async_add_entities):
             EnphaseEditorDaySwitch(entry.entry_id, key, is_new=True)
         )
 
+    # Add notification toggle switch
+    switches.append(EnphaseNotificationSwitch(entry))
+
     async_add_entities(switches, True)
 
 
@@ -110,3 +113,32 @@ class EnphaseEditorDaySwitch(SwitchEntity):
     @property
     def device_info(self):
         return schedule_editor_device_info(self.entry_id)
+
+
+class EnphaseNotificationSwitch(SwitchEntity):
+    """Switch to toggle notifications for schedule operations."""
+
+    def __init__(self, entry):
+        self.entry = entry
+        self._attr_name = "Enphase Notifications"
+        self._attr_unique_id = f"{entry.entry_id}_notifications"
+
+    @property
+    def is_on(self) -> bool:
+        return self.entry.options.get("notifications_enabled", True)
+
+    async def async_turn_on(self) -> None:
+        self.hass.config_entries.async_update_entry(
+            self.entry, options={**self.entry.options, "notifications_enabled": True}
+        )
+        self.async_write_ha_state()
+
+    async def async_turn_off(self) -> None:
+        self.hass.config_entries.async_update_entry(
+            self.entry, options={**self.entry.options, "notifications_enabled": False}
+        )
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self):
+        return battery_device_info(self.entry.entry_id)

--- a/custom_components/enphase_envoy_cloud_control/switch.py
+++ b/custom_components/enphase_envoy_cloud_control/switch.py
@@ -27,9 +27,6 @@ async def async_setup_entry(hass, entry, async_add_entities):
             EnphaseEditorDaySwitch(entry.entry_id, key, is_new=True)
         )
 
-    # Add notification toggle switch
-    switches.append(EnphaseNotificationSwitch(entry))
-
     async_add_entities(switches, True)
 
 
@@ -113,32 +110,3 @@ class EnphaseEditorDaySwitch(SwitchEntity):
     @property
     def device_info(self):
         return schedule_editor_device_info(self.entry_id)
-
-
-class EnphaseNotificationSwitch(SwitchEntity):
-    """Switch to toggle notifications for schedule operations."""
-
-    def __init__(self, entry):
-        self.entry = entry
-        self._attr_name = "Enphase Notifications"
-        self._attr_unique_id = f"{entry.entry_id}_notifications"
-
-    @property
-    def is_on(self) -> bool:
-        return self.entry.options.get("notifications_enabled", True)
-
-    async def async_turn_on(self) -> None:
-        self.hass.config_entries.async_update_entry(
-            self.entry, options={**self.entry.options, "notifications_enabled": True}
-        )
-        self.async_write_ha_state()
-
-    async def async_turn_off(self) -> None:
-        self.hass.config_entries.async_update_entry(
-            self.entry, options={**self.entry.options, "notifications_enabled": False}
-        )
-        self.async_write_ha_state()
-
-    @property
-    def device_info(self):
-        return battery_device_info(self.entry.entry_id)


### PR DESCRIPTION
I find the persistent notifications to be noisy, so I added an option in the config to make them toggleable.

Tested locally by running my own fork and seems to work with no issues.