### PR TITLE
v1.7.0: code quality pass + feature roadmap (reauth, multi-account, verified deletes, conflict detection, new sensors, diagnostics, blueprints)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 This custom integration lets Home Assistant read and control Enphase battery settings using the same web endpoints the Enlighten / Battery Profile UI uses (not the official API). It focuses on **battery schedules** (cfg / dtg / rbd) and provides a simple, dashboard-friendly way to **view**, **add**, **edit**, and **delete** schedules.
 
+### Glossary
+
+| Term | Meaning |
+|------|---------|
+| **CFG** | **Charge from Grid** — charge the battery from the grid (e.g. during cheap tariff windows) |
+| **DTG** | **Discharge to Grid** — export battery energy to the grid |
+| **RBD** | **Restrict Battery Discharge** — stop the battery from discharging (e.g. save it for peak hours) |
+
+> **Note:** CFG and DTG must be enabled for your site by Enphase. If a feature is not enabled, the cloud may silently re-create deleted schedules (the integration detects this and tells you).
+
 ---
 
 ## What this integration gives you
@@ -31,7 +41,11 @@ This mirrors the Enlighten scheduling workflow, but uses standard Home Assistant
 ## Requirements
 
 - Home Assistant with the ability to install custom integrations
-- Your Enphase Enlighten credentials (username and password) 
+- Your Enphase Enlighten **homeowner** credentials (the email and password you use at enlighten.enphaseenergy.com)
+
+Credentials are validated during setup — if the login fails you will see an error in the setup form instead of broken entities later. If your password changes afterwards, Home Assistant will prompt you to **reauthenticate** (Settings → Devices & services → the integration shows a "Reauthenticate" repair).
+
+Multiple Enphase accounts are supported: add the integration once per account. Each entry keeps its own login session and token cache.
 
 ---
 
@@ -81,6 +95,14 @@ This mirrors the Enlighten scheduling workflow, but uses standard Home Assistant
 - `switch.<...dtg enabled...>`
 - `switch.<...rbd enabled...>`
 - `button.force_cloud_refresh`
+
+### Battery setting sensors (read-only, created when your system reports them)
+- `sensor.enphase_battery_reserve` — backup reserve percentage
+- `sensor.enphase_battery_profile` — active system profile
+- `sensor.enphase_battery_grid_mode` — current grid mode
+- `sensor.enphase_battery_very_low_soc` — very-low state-of-charge threshold
+
+These come straight from the battery settings payload the integration already polls; no extra cloud calls are made. If a field is not present for your system, the sensor is simply not created.
 
 ### Schedule editor controls
 **Edit existing schedule**
@@ -190,6 +212,77 @@ cards:
 
 ---
 
+## Services & automations
+
+The integration registers these services (see Developer Tools → Actions for full schemas):
+
+| Service | Purpose |
+|---------|---------|
+| `enphase_envoy_cloud_control.force_refresh` | Refresh cloud data immediately |
+| `enphase_envoy_cloud_control.add_schedule` | Create a schedule (validates feature support and **rejects overlapping schedules**) |
+| `enphase_envoy_cloud_control.update_schedule` | Replace an existing schedule |
+| `enphase_envoy_cloud_control.delete_schedule` | Delete schedule(s) — **verifies the cloud actually removed them** |
+| `enphase_envoy_cloud_control.validate_schedule` | Ask Enphase whether a schedule type is currently valid for your site |
+
+### Example: dynamic cheap-tariff charge window
+
+When your energy provider signals a cheap window (e.g. via a price sensor turning a `binary_sensor` on), create a one-hour CFG schedule and enable charging; remove it when the window ends:
+
+```yaml
+automation:
+  - alias: "Enphase: start grid charging in cheap window"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.cheap_energy_window
+        to: "on"
+    action:
+      - service: enphase_envoy_cloud_control.add_schedule
+        data:
+          schedule_type: cfg
+          start_time: "{{ now().strftime('%H:%M') }}"
+          end_time: "{{ (now() + timedelta(hours=1)).strftime('%H:%M') }}"
+          limit: 100
+          days: ["{{ now().isoweekday() }}"]
+      - service: switch.turn_on
+        target:
+          entity_id: switch.enphase_cfg_mode
+
+  - alias: "Enphase: stop grid charging after cheap window"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.cheap_energy_window
+        to: "off"
+    action:
+      - service: switch.turn_off
+        target:
+          entity_id: switch.enphase_cfg_mode
+      # Delete today's CFG schedules using the summary sensor's attributes
+      - service: enphase_envoy_cloud_control.delete_schedule
+        data:
+          confirm: true
+          schedule_ids: >-
+            {{ state_attr('sensor.enphase_schedules_summary', 'schedules')
+               | selectattr('type', 'eq', 'cfg')
+               | map(attribute='id') | list }}
+```
+
+### Blueprints
+
+Two importable blueprints ship in [`blueprints/`](blueprints/):
+
+- **Charge from grid during a time window** — toggles the CFG switch on/off at fixed times
+- **Block battery discharge during a time window** — toggles the RBD switch on/off (e.g. peak hours)
+
+Import via **Settings → Automations & scenes → Blueprints → Import blueprint** using the raw GitHub URL of the YAML file.
+
+---
+
+## Diagnostics
+
+The integration supports Home Assistant diagnostics: on the integration page choose **Download diagnostics** to get a redacted dump (credentials, tokens and IDs removed) that you can attach to bug reports.
+
+---
+
 ## Troubleshooting
 
 ### Schedules not showing / stale data
@@ -202,6 +295,13 @@ cards:
 * Check Home Assistant logs for the response body.
 * Ensure the day selection is not empty.
 * Ensure start and end are different.
+* Overlapping schedules of the same type are rejected before they reach Enphase — adjust the times or days.
+* If a deletion reports that Enphase restored the schedule, that feature (CFG/DTG) is likely not enabled for your site — contact Enphase support.
+
+### Authentication problems
+
+* A persistent notification appears when cloud authentication fails; the integration retries automatically.
+* After repeated failures Home Assistant shows a **Reauthenticate** prompt on the integration — enter your current Enlighten password there. No need to remove and re-add the integration.
 
 ### Device controls look cluttered
 

--- a/blueprints/enphase_block_discharge_window.yaml
+++ b/blueprints/enphase_block_discharge_window.yaml
@@ -1,0 +1,53 @@
+blueprint:
+  name: "Enphase: block battery discharge during a time window"
+  description: >-
+    Turns the Enphase "Restrict Battery Discharge" (RBD) mode on at a start
+    time and off at an end time — useful for preserving the battery for
+    evening peak hours. Pick the "Enphase RBD Mode" switch created by the
+    Enphase Envoy Cloud Control integration.
+  domain: automation
+  source_url: https://github.com/chinedu40/hacs_enphase_envoy_cloud/blob/main/blueprints/enphase_block_discharge_window.yaml
+  input:
+    rbd_switch:
+      name: Restrict Battery Discharge switch
+      description: The "Enphase RBD Mode" switch entity.
+      selector:
+        entity:
+          domain: switch
+    start_time:
+      name: Window start
+      description: When battery discharge should be blocked.
+      selector:
+        time:
+    end_time:
+      name: Window end
+      description: When battery discharge should be allowed again.
+      selector:
+        time:
+
+mode: single
+
+trigger:
+  - platform: time
+    at: !input start_time
+    id: window_start
+  - platform: time
+    at: !input end_time
+    id: window_end
+
+action:
+  - choose:
+      - conditions:
+          - condition: trigger
+            id: window_start
+        sequence:
+          - service: switch.turn_on
+            target:
+              entity_id: !input rbd_switch
+      - conditions:
+          - condition: trigger
+            id: window_end
+        sequence:
+          - service: switch.turn_off
+            target:
+              entity_id: !input rbd_switch

--- a/blueprints/enphase_charge_from_grid_window.yaml
+++ b/blueprints/enphase_charge_from_grid_window.yaml
@@ -1,0 +1,54 @@
+blueprint:
+  name: "Enphase: charge from grid during a time window"
+  description: >-
+    Turns the Enphase "Charge from Grid" (CFG) mode on at a start time and
+    off at an end time — useful for cheap-tariff windows. Pick the
+    "Enphase CFG Mode" switch created by the Enphase Envoy Cloud Control
+    integration. For dynamic tariffs, replace the time triggers with your
+    price sensor in the created automation.
+  domain: automation
+  source_url: https://github.com/chinedu40/hacs_enphase_envoy_cloud/blob/main/blueprints/enphase_charge_from_grid_window.yaml
+  input:
+    cfg_switch:
+      name: Charge from Grid switch
+      description: The "Enphase CFG Mode" switch entity.
+      selector:
+        entity:
+          domain: switch
+    start_time:
+      name: Window start
+      description: When grid charging should begin.
+      selector:
+        time:
+    end_time:
+      name: Window end
+      description: When grid charging should stop.
+      selector:
+        time:
+
+mode: single
+
+trigger:
+  - platform: time
+    at: !input start_time
+    id: window_start
+  - platform: time
+    at: !input end_time
+    id: window_end
+
+action:
+  - choose:
+      - conditions:
+          - condition: trigger
+            id: window_start
+        sequence:
+          - service: switch.turn_on
+            target:
+              entity_id: !input cfg_switch
+      - conditions:
+          - condition: trigger
+            id: window_end
+        sequence:
+          - service: switch.turn_off
+            target:
+              entity_id: !input cfg_switch

--- a/custom_components/enphase_envoy_cloud_control/__init__.py
+++ b/custom_components/enphase_envoy_cloud_control/__init__.py
@@ -13,13 +13,16 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.components import persistent_notification
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.event import async_call_later
 
 from .const import DEFAULT_POLL_INTERVAL, DOMAIN
 from .coordinator import EnphaseCoordinator
-from .editor import default_editor_state, default_new_editor_state
+from .editor import _collect_schedules, default_editor_state, default_new_editor_state
+from .enphase_client import AuthError
+
+__all__ = ["async_setup_entry", "async_unload_entry"]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -126,7 +129,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     entry.async_on_unload(entry.add_update_listener(_async_handle_options_update))
 
-    await coordinator.async_initialize_auth()
+    try:
+        await coordinator.async_initialize_auth()
+    except AuthError as err:
+        raise ConfigEntryNotReady(f"Enphase authentication failed: {err}") from err
     await coordinator.async_config_entry_first_refresh()
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -246,6 +252,8 @@ def _register_services(hass: HomeAssistant) -> None:
         limit = int(data["limit"])
         days = sorted({int(day) for day in cv.ensure_list(data["days"])})
 
+        # Input validation lives here (not in the voluptuous schema) so the
+        # user gets a clear, actionable error message in the UI.
         if not days:
             raise HomeAssistantError("Select at least one day for the schedule.")
 
@@ -615,38 +623,6 @@ def _schedule_post_action_refresh(
     hass.loop.call_soon_threadsafe(
         hass.async_create_task, _post_action_refresh(coordinator)
     )
-
-
-def _collect_schedules(coordinator: EnphaseCoordinator, mode: str) -> list[dict[str, Any]]:
-    """Collect cached schedules for the given mode."""
-    data_root = coordinator.data or {}
-    schedule_block = data_root.get("data", {}).get(f"{mode}Control", {})
-    schedules = schedule_block.get("schedules")
-    if isinstance(schedules, list):
-        return schedules
-
-    fallback = data_root.get("schedules", {})
-    if isinstance(fallback, dict):
-        candidate = fallback.get(mode)
-        if isinstance(candidate, dict) and isinstance(candidate.get("details"), list):
-            return candidate["details"]
-        if isinstance(candidate, list):
-            return candidate
-        inner = fallback.get("data", {}).get(mode)
-        if isinstance(inner, dict) and isinstance(inner.get("details"), list):
-            return inner["details"]
-        if isinstance(inner, list):
-            return inner
-
-    cached = getattr(coordinator.client, "_last_schedules", None)
-    if isinstance(cached, dict):
-        candidate = cached.get(mode)
-        if isinstance(candidate, dict) and isinstance(candidate.get("details"), list):
-            return candidate["details"]
-        if isinstance(candidate, list):
-            return candidate
-
-    return []
 
 
 def _mode_settings_from_data(

--- a/custom_components/enphase_envoy_cloud_control/__init__.py
+++ b/custom_components/enphase_envoy_cloud_control/__init__.py
@@ -19,7 +19,12 @@ from homeassistant.helpers.event import async_call_later
 
 from .const import DEFAULT_POLL_INTERVAL, DOMAIN
 from .coordinator import EnphaseCoordinator
-from .editor import _collect_schedules, default_editor_state, default_new_editor_state
+from .editor import (
+    _collect_schedules,
+    default_editor_state,
+    default_new_editor_state,
+    normalize_schedules,
+)
 from .enphase_client import AuthError
 
 __all__ = ["async_setup_entry", "async_unload_entry"]
@@ -109,6 +114,86 @@ VALIDATE_SCHEDULE_SCHEMA = vol.Schema(
         vol.Required("schedule_type"): vol.All(cv.string, vol.Lower, vol.In(["cfg", "dtg", "rbd"])),
     }
 )
+
+
+def _hhmm_to_minutes(value: str) -> int:
+    """Convert 'HH:MM' to minutes since midnight."""
+    hours, minutes = str(value).split(":")
+    return int(hours) * 60 + int(minutes)
+
+
+def _time_intervals(start: str, end: str) -> list[tuple[int, int]]:
+    """Return minute intervals for a schedule, splitting midnight wraps."""
+    try:
+        start_min = _hhmm_to_minutes(start)
+        end_min = _hhmm_to_minutes(end)
+    except (ValueError, AttributeError):
+        return []
+    if start_min == end_min:
+        return []
+    if start_min < end_min:
+        return [(start_min, end_min)]
+    return [(start_min, 1440), (0, end_min)]
+
+
+def _find_schedule_conflict(
+    coordinator: EnphaseCoordinator,
+    schedule_type: str,
+    start_str: str,
+    end_str: str,
+    days: list[int],
+    exclude_id: str | None = None,
+) -> dict[str, Any] | None:
+    """Return the first existing same-mode schedule that overlaps, if any."""
+    new_intervals = _time_intervals(start_str, end_str)
+    new_days = set(days)
+    for sched in normalize_schedules(coordinator):
+        if sched.get("type") != schedule_type:
+            continue
+        if exclude_id is not None and str(sched.get("id")) == str(exclude_id):
+            continue
+        if not new_days & set(sched.get("days") or []):
+            continue
+        for new_iv in new_intervals:
+            for old_iv in _time_intervals(sched.get("start", ""), sched.get("end", "")):
+                if new_iv[0] < old_iv[1] and old_iv[0] < new_iv[1]:
+                    return sched
+    return None
+
+
+def _check_mode_supported(coordinator: EnphaseCoordinator, schedule_type: str) -> None:
+    """Raise if the battery settings payload shows no support for this mode.
+
+    Enphase silently re-creates schedules deleted for non-enabled features
+    (see issue #38), so refuse to create them in the first place.
+    """
+    inner = (coordinator.data or {}).get("data", {})
+    if isinstance(inner, dict) and inner and f"{schedule_type}Control" not in inner:
+        raise HomeAssistantError(
+            f"Your Enphase system does not appear to support "
+            f"{schedule_type.upper()} (no {schedule_type}Control block in the "
+            "battery settings). This feature may need to be enabled by Enphase "
+            "for your site."
+        )
+
+
+def _extract_schedule_ids(payload: Any) -> set[str]:
+    """Collect every scheduleId present anywhere in a schedules payload."""
+    ids: set[str] = set()
+
+    def _walk(node: Any) -> None:
+        if isinstance(node, dict):
+            schedule_id = node.get("scheduleId")
+            if schedule_id is not None:
+                ids.add(str(schedule_id))
+            for value in node.values():
+                _walk(value)
+        elif isinstance(node, list):
+            for value in node:
+                _walk(value)
+
+    _walk(payload)
+    return ids
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -262,6 +347,18 @@ def _register_services(hass: HomeAssistant) -> None:
         if start_str == end_str:
             raise HomeAssistantError("Start time and end time must differ for a schedule.")
 
+        _check_mode_supported(coordinator, schedule_type)
+
+        conflict = _find_schedule_conflict(
+            coordinator, schedule_type, start_str, end_str, days
+        )
+        if conflict:
+            raise HomeAssistantError(
+                f"Schedule overlaps an existing {schedule_type.upper()} schedule "
+                f"({conflict.get('start')}–{conflict.get('end')}, "
+                f"id {conflict.get('id')}). Adjust the times or days."
+            )
+
         timezone = hass.config.time_zone or "UTC"
 
         try:
@@ -353,6 +450,18 @@ def _register_services(hass: HomeAssistant) -> None:
             raise HomeAssistantError("Start time and end time must differ for a schedule.")
         if not days:
             raise HomeAssistantError("Select at least one day for the schedule.")
+
+        _check_mode_supported(coordinator, schedule_type)
+
+        conflict = _find_schedule_conflict(
+            coordinator, schedule_type, start_str, end_str, days, exclude_id=schedule_id
+        )
+        if conflict:
+            raise HomeAssistantError(
+                f"Schedule overlaps an existing {schedule_type.upper()} schedule "
+                f"({conflict.get('start')}–{conflict.get('end')}, "
+                f"id {conflict.get('id')}). Adjust the times or days."
+            )
 
         timezone = hass.config.time_zone or "UTC"
 
@@ -475,6 +584,33 @@ def _register_services(hass: HomeAssistant) -> None:
                 raise HomeAssistantError(
                     f"Failed to delete schedule {schedule_id}: {exc}"
                 ) from exc
+
+        # Verify the deletion actually stuck: Enphase silently restores
+        # schedules for features that are not enabled for the site (issue #38),
+        # while still returning a success status for the delete call.
+        await asyncio.sleep(2)
+        try:
+            remaining = await hass.async_add_executor_job(
+                coordinator.client.get_schedules
+            )
+        except Exception as exc:
+            _LOGGER.warning(
+                "[Enphase] Could not verify schedule deletion (fetch failed): %s",
+                exc,
+            )
+            remaining = None
+        if remaining is not None:
+            still_present = sorted(
+                set(schedule_ids) & _extract_schedule_ids(remaining)
+            )
+            if still_present:
+                raise HomeAssistantError(
+                    "Enphase reported success but did not actually delete "
+                    f"schedule(s): {', '.join(still_present)}. This usually "
+                    "means the feature (e.g. CFG/DTG) is not enabled for your "
+                    "system, so the cloud restores the schedule. Contact "
+                    "Enphase support to remove it."
+                )
 
         affected_modes = {
             schedule_modes[sched_id]

--- a/custom_components/enphase_envoy_cloud_control/button.py
+++ b/custom_components/enphase_envoy_cloud_control/button.py
@@ -1,18 +1,41 @@
+"""Buttons for cloud refresh and schedule add/save/delete actions."""
+
 from __future__ import annotations
+
 import logging
+from typing import Any
 
 from homeassistant.components import persistent_notification
 from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
+from .coordinator import EnphaseCoordinator
 from .device import battery_device_info, schedule_editor_device_info
 from .editor import days_list_from_editor, get_coordinator, get_entry_data
 
+__all__ = [
+    "EnphaseAddScheduleButton",
+    "EnphaseDeleteScheduleButton",
+    "EnphaseForceCloudRefreshButton",
+    "EnphaseNewScheduleAddButton",
+    "EnphaseScheduleDeleteButton",
+    "EnphaseScheduleSaveButton",
+    "async_setup_entry",
+]
+
 _LOGGER = logging.getLogger(__name__)
 
-async def async_setup_entry(hass, entry, async_add_entities):
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Set up the Enphase Force Cloud Refresh button."""
     coordinator = get_coordinator(hass, entry.entry_id)
     async_add_entities(
@@ -30,7 +53,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
 class EnphaseForceCloudRefreshButton(CoordinatorEntity, ButtonEntity):
     """Button to manually force data refresh from the cloud."""
 
-    def __init__(self, coordinator):
+    def __init__(self, coordinator: EnphaseCoordinator) -> None:
         super().__init__(coordinator)
         self._attr_name = "Force Cloud Refresh"
         self._attr_unique_id = f"{coordinator.entry.entry_id}_force_refresh"
@@ -41,7 +64,7 @@ class EnphaseForceCloudRefreshButton(CoordinatorEntity, ButtonEntity):
     def available(self) -> bool:
         return True  # Always available
 
-    async def async_press(self):
+    async def async_press(self) -> None:
         """Handle button press."""
         _LOGGER.info("[Enphase] Force Cloud Refresh button pressed.")
         try:
@@ -51,7 +74,7 @@ class EnphaseForceCloudRefreshButton(CoordinatorEntity, ButtonEntity):
             _LOGGER.error("[Enphase] Data refresh failed: %s", e)
 
     @property
-    def device_info(self):
+    def device_info(self) -> dict[str, Any]:
         """Attach this button to the Enphase device."""
         return battery_device_info(self.coordinator.entry.entry_id)
 
@@ -63,7 +86,7 @@ class EnphaseAddScheduleButton(CoordinatorEntity, ButtonEntity):
     _attr_icon = "mdi:calendar-plus"
     _attr_entity_category = EntityCategory.CONFIG
 
-    def __init__(self, coordinator):
+    def __init__(self, coordinator: EnphaseCoordinator) -> None:
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.entry.entry_id}_add_schedule"
 
@@ -75,11 +98,8 @@ class EnphaseAddScheduleButton(CoordinatorEntity, ButtonEntity):
                 self.coordinator.entry.entry_id,
                 context={"source": "schedule_add_button"},
             )
-        except Exception as exc:
-            _LOGGER.exception(
-                "[Enphase] Failed to start add schedule options flow: %s",
-                exc,
-            )
+        except Exception:
+            _LOGGER.exception("[Enphase] Failed to start add schedule options flow")
             return
         flow_id = getattr(flow, "flow_id", None)
         _LOGGER.debug(
@@ -97,7 +117,7 @@ class EnphaseAddScheduleButton(CoordinatorEntity, ButtonEntity):
             )
 
     @property
-    def device_info(self):
+    def device_info(self) -> dict[str, Any]:
         return battery_device_info(self.coordinator.entry.entry_id)
 
 
@@ -108,7 +128,7 @@ class EnphaseDeleteScheduleButton(CoordinatorEntity, ButtonEntity):
     _attr_icon = "mdi:calendar-remove"
     _attr_entity_category = EntityCategory.CONFIG
 
-    def __init__(self, coordinator):
+    def __init__(self, coordinator: EnphaseCoordinator) -> None:
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.entry.entry_id}_delete_schedule"
 
@@ -120,11 +140,8 @@ class EnphaseDeleteScheduleButton(CoordinatorEntity, ButtonEntity):
                 self.coordinator.entry.entry_id,
                 context={"source": "schedule_delete_button"},
             )
-        except Exception as exc:
-            _LOGGER.exception(
-                "[Enphase] Failed to start delete schedule options flow: %s",
-                exc,
-            )
+        except Exception:
+            _LOGGER.exception("[Enphase] Failed to start delete schedule options flow")
             return
         flow_id = getattr(flow, "flow_id", None)
         _LOGGER.debug(
@@ -142,7 +159,7 @@ class EnphaseDeleteScheduleButton(CoordinatorEntity, ButtonEntity):
             )
 
     @property
-    def device_info(self):
+    def device_info(self) -> dict[str, Any]:
         return battery_device_info(self.coordinator.entry.entry_id)
 
 
@@ -153,7 +170,7 @@ class EnphaseScheduleSaveButton(ButtonEntity):
     _attr_icon = "mdi:content-save"
     _attr_entity_category = EntityCategory.CONFIG
 
-    def __init__(self, entry_id: str):
+    def __init__(self, entry_id: str) -> None:
         self.entry_id = entry_id
         self._attr_unique_id = f"{entry_id}_schedule_save"
 
@@ -182,7 +199,7 @@ class EnphaseScheduleSaveButton(ButtonEntity):
         )
 
     @property
-    def device_info(self):
+    def device_info(self) -> dict[str, Any]:
         return schedule_editor_device_info(self.entry_id)
 
 
@@ -193,7 +210,7 @@ class EnphaseScheduleDeleteButton(ButtonEntity):
     _attr_icon = "mdi:calendar-remove"
     _attr_entity_category = EntityCategory.CONFIG
 
-    def __init__(self, entry_id: str):
+    def __init__(self, entry_id: str) -> None:
         self.entry_id = entry_id
         self._attr_unique_id = f"{entry_id}_schedule_delete"
 
@@ -215,7 +232,7 @@ class EnphaseScheduleDeleteButton(ButtonEntity):
         )
 
     @property
-    def device_info(self):
+    def device_info(self) -> dict[str, Any]:
         return schedule_editor_device_info(self.entry_id)
 
 
@@ -226,7 +243,7 @@ class EnphaseNewScheduleAddButton(ButtonEntity):
     _attr_icon = "mdi:calendar-plus"
     _attr_entity_category = EntityCategory.CONFIG
 
-    def __init__(self, entry_id: str):
+    def __init__(self, entry_id: str) -> None:
         self.entry_id = entry_id
         self._attr_unique_id = f"{entry_id}_new_schedule_add"
 
@@ -249,5 +266,5 @@ class EnphaseNewScheduleAddButton(ButtonEntity):
         )
 
     @property
-    def device_info(self):
+    def device_info(self) -> dict[str, Any]:
         return schedule_editor_device_info(self.entry_id)

--- a/custom_components/enphase_envoy_cloud_control/config_flow.py
+++ b/custom_components/enphase_envoy_cloud_control/config_flow.py
@@ -1,11 +1,20 @@
+"""Config flow for Enphase Envoy Cloud Control (Enlighten credentials)."""
+
 from __future__ import annotations
+
 import logging
+from typing import Any
+
 import voluptuous as vol
+
 from homeassistant import config_entries
 from homeassistant.core import callback
-from homeassistant.helpers import selector
+from homeassistant.data_entry_flow import FlowResult
+
 from .const import DOMAIN
 from .options_flow import EnphaseOptionsFlowHandler
+
+__all__ = ["EnphaseConfigFlow"]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -15,7 +24,9 @@ class EnphaseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Handle the initial step for setup."""
         errors = {}
 
@@ -47,7 +58,9 @@ class EnphaseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry):
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> EnphaseOptionsFlowHandler:
         """Return the options flow handler."""
         _LOGGER.debug(
             "[Enphase] Creating options flow handler for entry_id=%s",

--- a/custom_components/enphase_envoy_cloud_control/config_flow.py
+++ b/custom_components/enphase_envoy_cloud_control/config_flow.py
@@ -3,15 +3,18 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from typing import Any
 
+import requests
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 
 from .const import DOMAIN
+from .enphase_client import AuthError, EnphaseClient
 from .options_flow import EnphaseOptionsFlowHandler
 
 __all__ = ["EnphaseConfigFlow"]
@@ -19,10 +22,29 @@ __all__ = ["EnphaseConfigFlow"]
 _LOGGER = logging.getLogger(__name__)
 
 
+async def _async_validate_credentials(
+    hass: HomeAssistant, email: str, password: str
+) -> str | None:
+    """Try a real Enlighten login; return an error code or None on success."""
+    client = EnphaseClient(email, password, None, None, persist_cache=False)
+    try:
+        await hass.async_add_executor_job(client.ensure_authenticated)
+    except AuthError as err:
+        _LOGGER.warning("[Enphase] Credential validation failed: %s", err)
+        return "invalid_auth"
+    except requests.RequestException as err:
+        _LOGGER.warning("[Enphase] Could not reach Enphase cloud: %s", err)
+        return "cannot_connect"
+    return None
+
+
 class EnphaseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle the configuration flow for Enphase Envoy Cloud Control."""
 
     VERSION = 1
+
+    def __init__(self) -> None:
+        self._reauth_entry_id: str | None = None
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -31,19 +53,24 @@ class EnphaseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
-            # Basic validation
             if not user_input.get("email") or not user_input.get("password"):
                 errors["base"] = "missing_credentials"
             else:
                 await self.async_set_unique_id(user_input["email"])
                 self._abort_if_unique_id_configured()
-                _LOGGER.info(
-                    "[Enphase] Creating new config entry for %s",
-                    user_input["email"],
+                error = await _async_validate_credentials(
+                    self.hass, user_input["email"], user_input["password"]
                 )
-                return self.async_create_entry(
-                    title="Enphase Envoy Cloud Control", data=user_input
-                )
+                if error:
+                    errors["base"] = error
+                else:
+                    _LOGGER.info(
+                        "[Enphase] Creating new config entry for %s",
+                        user_input["email"],
+                    )
+                    return self.async_create_entry(
+                        title="Enphase Envoy Cloud Control", data=user_input
+                    )
 
         data_schema = vol.Schema(
             {
@@ -54,6 +81,43 @@ class EnphaseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user", data_schema=data_schema, errors=errors
+        )
+
+    async def async_step_reauth(self, entry_data: Mapping[str, Any]) -> FlowResult:
+        """Handle reauthentication when stored credentials stop working."""
+        self._reauth_entry_id = self.context["entry_id"]
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Ask for an updated password and validate it."""
+        entry = self.hass.config_entries.async_get_entry(self._reauth_entry_id)
+        if entry is None:
+            return self.async_abort(reason="reauth_failed")
+
+        errors = {}
+        email = entry.data.get("email", "")
+
+        if user_input is not None:
+            error = await _async_validate_credentials(
+                self.hass, email, user_input["password"]
+            )
+            if error:
+                errors["base"] = error
+            else:
+                self.hass.config_entries.async_update_entry(
+                    entry, data={**entry.data, "password": user_input["password"]}
+                )
+                await self.hass.config_entries.async_reload(entry.entry_id)
+                _LOGGER.info("[Enphase] Reauthentication successful for %s", email)
+                return self.async_abort(reason="reauth_successful")
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema({vol.Required("password"): str}),
+            errors=errors,
+            description_placeholders={"email": email},
         )
 
     @staticmethod

--- a/custom_components/enphase_envoy_cloud_control/const.py
+++ b/custom_components/enphase_envoy_cloud_control/const.py
@@ -2,6 +2,28 @@
 
 import logging
 
+__all__ = [
+    "BASE_URL",
+    "BATTERY_URL",
+    "CACHE_DIR",
+    "CACHE_FILE",
+    "CONF_BATTERY_ID",
+    "CONF_EMAIL",
+    "CONF_PASSWORD",
+    "CONF_SITE_ID",
+    "CONF_USER_ID",
+    "DEFAULT_POLL_INTERVAL",
+    "DEVICE_KIND_BATTERY",
+    "DEVICE_KIND_SCHEDULE_EDITOR",
+    "DOMAIN",
+    "JWT_URL",
+    "LOGGER",
+    "LOGIN_URL",
+    "NAME",
+    "SCHEDULE_URL",
+    "VERSION",
+]
+
 DOMAIN = "enphase_envoy_cloud_control"
 NAME = "Enphase Envoy Cloud Control"
 VERSION = "1.6.0"

--- a/custom_components/enphase_envoy_cloud_control/const.py
+++ b/custom_components/enphase_envoy_cloud_control/const.py
@@ -26,7 +26,7 @@ __all__ = [
 
 DOMAIN = "enphase_envoy_cloud_control"
 NAME = "Enphase Envoy Cloud Control"
-VERSION = "1.6.0"
+VERSION = "1.7.0"
 DEVICE_KIND_BATTERY = "battery"
 DEVICE_KIND_SCHEDULE_EDITOR = "schedule_editor"
 

--- a/custom_components/enphase_envoy_cloud_control/coordinator.py
+++ b/custom_components/enphase_envoy_cloud_control/coordinator.py
@@ -11,6 +11,7 @@ from datetime import timedelta, datetime, timezone
 from typing import Any
 
 from homeassistant.components import persistent_notification
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
@@ -23,6 +24,10 @@ __all__ = ["EnphaseCoordinator"]
 _LOGGER = LOGGER
 
 AUTH_NOTIFICATION_ID = f"{DOMAIN}_auth_failure"
+
+# Consecutive auth failures tolerated as transient before triggering the
+# reauthentication flow (cloud hiccups should not prompt for a password).
+AUTH_FAILURES_BEFORE_REAUTH = 3
 
 
 class EnphaseCoordinator(DataUpdateCoordinator[dict[str, Any]]):
@@ -37,6 +42,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             password=entry.data.get("password"),
             user_id=entry.data.get("user_id"),
             battery_id=entry.data.get("battery_id"),
+            cache_key=entry.entry_id,
         )
 
         # Custom polling interval (default 30s)
@@ -47,6 +53,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.last_refresh: str | None = None
         self.last_successful_poll: datetime | None = None
         self._auth_notified = False
+        self._auth_failure_count = 0
 
         super().__init__(
             hass,
@@ -61,8 +68,19 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             _LOGGER.debug("[Enphase] Starting scheduled data update.")
             data = await self.hass.async_add_executor_job(self._fetch)
         except AuthError as err:
-            _LOGGER.error("[Enphase] Authentication failed during update: %s", err)
+            self._auth_failure_count += 1
+            _LOGGER.error(
+                "[Enphase] Authentication failed during update (%s/%s): %s",
+                self._auth_failure_count,
+                AUTH_FAILURES_BEFORE_REAUTH,
+                err,
+            )
             self._async_notify_auth_failure(err)
+            if self._auth_failure_count >= AUTH_FAILURES_BEFORE_REAUTH:
+                # Persistent failure: trigger Home Assistant's reauth flow.
+                raise ConfigEntryAuthFailed(
+                    f"Enphase authentication failed repeatedly: {err}"
+                ) from err
             raise UpdateFailed(f"Authentication failed: {err}") from err
         except Exception as err:
             _LOGGER.error("[Enphase] Error updating data: %s", err)
@@ -70,6 +88,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         self.last_successful_poll = datetime.now(timezone.utc)
         self.last_refresh = self.last_successful_poll.isoformat()
+        self._auth_failure_count = 0
         self._async_dismiss_auth_failure()
         return data
 

--- a/custom_components/enphase_envoy_cloud_control/coordinator.py
+++ b/custom_components/enphase_envoy_cloud_control/coordinator.py
@@ -1,18 +1,34 @@
+"""Data update coordinator for Enphase Envoy Cloud Control.
+
+Polls the Enphase cloud for battery settings and schedules, merges them
+into a single data structure, and surfaces authentication failures to the
+user via a persistent notification.
+"""
+
 from __future__ import annotations
+
 from datetime import timedelta, datetime, timezone
+from typing import Any
+
+from homeassistant.components import persistent_notification
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
-from .const import LOGGER, DEFAULT_POLL_INTERVAL
-from .enphase_client import EnphaseClient
+
+from .const import DOMAIN, LOGGER, DEFAULT_POLL_INTERVAL
+from .enphase_client import AuthError, EnphaseClient
+
+__all__ = ["EnphaseCoordinator"]
 
 _LOGGER = LOGGER
 
+AUTH_NOTIFICATION_ID = f"{DOMAIN}_auth_failure"
 
-class EnphaseCoordinator(DataUpdateCoordinator):
+
+class EnphaseCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Manages periodic updates from the Enphase Cloud."""
 
-    def __init__(self, hass: HomeAssistant, entry: ConfigEntry):
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         """Initialize the coordinator."""
         self.hass = hass
         self.entry = entry
@@ -23,13 +39,14 @@ class EnphaseCoordinator(DataUpdateCoordinator):
             battery_id=entry.data.get("battery_id"),
         )
 
-        # ✅ Custom polling interval (default 30s)
+        # Custom polling interval (default 30s)
         poll_interval = entry.options.get("poll_interval", DEFAULT_POLL_INTERVAL)
         self.update_interval = timedelta(seconds=poll_interval)
-        _LOGGER.info(f"[Enphase] Polling interval set to {poll_interval}s")
+        _LOGGER.info("[Enphase] Polling interval set to %ss", poll_interval)
 
-        self.last_refresh = None
-        self.last_successful_poll = None
+        self.last_refresh: str | None = None
+        self.last_successful_poll: datetime | None = None
+        self._auth_notified = False
 
         super().__init__(
             hass,
@@ -38,77 +55,108 @@ class EnphaseCoordinator(DataUpdateCoordinator):
             update_interval=self.update_interval,
         )
 
-    async def _async_update_data(self):
+    async def _async_update_data(self) -> dict[str, Any]:
         """Fetch latest data from Enphase Cloud."""
         try:
             _LOGGER.debug("[Enphase] Starting scheduled data update.")
             data = await self.hass.async_add_executor_job(self._fetch)
-            self.last_successful_poll = datetime.now(timezone.utc)
-            self.last_refresh = self.last_successful_poll.isoformat()
-            return data
+        except AuthError as err:
+            _LOGGER.error("[Enphase] Authentication failed during update: %s", err)
+            self._async_notify_auth_failure(err)
+            raise UpdateFailed(f"Authentication failed: {err}") from err
         except Exception as err:
             _LOGGER.error("[Enphase] Error updating data: %s", err)
-            raise UpdateFailed(err)
+            raise UpdateFailed(err) from err
 
-    def _fetch(self):
+        self.last_successful_poll = datetime.now(timezone.utc)
+        self.last_refresh = self.last_successful_poll.isoformat()
+        self._async_dismiss_auth_failure()
+        return data
+
+    def _async_notify_auth_failure(self, err: AuthError) -> None:
+        """Surface an authentication failure as a persistent notification.
+
+        Deliberately ignores the ``notifications_enabled`` option: that toggle
+        gates informational success messages, while an auth failure means the
+        integration is dead until the user acts, so it must always be visible.
+        """
+        if "persistent_notification" not in self.hass.config.components:
+            return
+        persistent_notification.async_create(
+            self.hass,
+            (
+                "⚠️ Enphase cloud authentication failed and entities are "
+                f"unavailable: {err}\n\nCheck your Enphase Enlighten email and "
+                "password. The integration will keep retrying automatically."
+            ),
+            title="Enphase Envoy Cloud Control",
+            notification_id=AUTH_NOTIFICATION_ID,
+        )
+        self._auth_notified = True
+
+    def _async_dismiss_auth_failure(self) -> None:
+        """Dismiss the auth-failure notification after a successful update."""
+        if not self._auth_notified:
+            return
+        if "persistent_notification" in self.hass.config.components:
+            persistent_notification.async_dismiss(self.hass, AUTH_NOTIFICATION_ID)
+        self._auth_notified = False
+
+    def _fetch(self) -> dict[str, Any]:
         """Synchronous fetch — runs inside executor."""
-        try:
-            battery_data = self.client.battery_settings() or {}
-            schedules = self.client.get_schedules() or {}
+        battery_data = self.client.battery_settings() or {}
+        schedules = self.client.get_schedules() or {}
 
-            # Persist the last schedule payload for entities that reference it
-            # outside of the coordinator data structure (legacy behaviour).
-            setattr(self.client, "_last_schedules", schedules)
+        # Persist the last schedule payload for entities that reference it
+        # outside of the coordinator data structure (legacy behaviour).
+        setattr(self.client, "_last_schedules", schedules)
 
-            # Normalise schedule payload to the inner "data" block when present.
-            schedule_block = schedules.get("data") if isinstance(schedules, dict) else None
-            if not schedule_block:
-                schedule_block = schedules if isinstance(schedules, dict) else {}
+        # Normalise schedule payload to the inner "data" block when present.
+        schedule_block = schedules.get("data") if isinstance(schedules, dict) else None
+        if not schedule_block:
+            schedule_block = schedules if isinstance(schedules, dict) else {}
 
-            inner_data = battery_data.get("data", battery_data)
+        inner_data = battery_data.get("data", battery_data)
 
-            # Merge concrete schedule details (start/end, limit, etc.) into the
-            # cfg/dtg/rbd control blocks so entities always read fresh values.
-            if isinstance(inner_data, dict) and isinstance(schedule_block, dict):
-                for mode in ("cfg", "dtg", "rbd"):
-                    details = schedule_block.get(mode)
-                    if not isinstance(details, dict):
-                        continue
-                    detail_list = details.get("details")
-                    if not isinstance(detail_list, list):
-                        continue
+        # Merge concrete schedule details (start/end, limit, etc.) into the
+        # cfg/dtg/rbd control blocks so entities always read fresh values.
+        if isinstance(inner_data, dict) and isinstance(schedule_block, dict):
+            for mode in ("cfg", "dtg", "rbd"):
+                details = schedule_block.get(mode)
+                if not isinstance(details, dict):
+                    continue
+                detail_list = details.get("details")
+                if not isinstance(detail_list, list):
+                    continue
 
-                    control_key = f"{mode}Control"
-                    control = inner_data.get(control_key)
-                    if not isinstance(control, dict):
-                        continue
-                    schedules_list = control.get("schedules")
-                    if not isinstance(schedules_list, list):
-                        continue
+                control_key = f"{mode}Control"
+                control = inner_data.get(control_key)
+                if not isinstance(control, dict):
+                    continue
+                schedules_list = control.get("schedules")
+                if not isinstance(schedules_list, list):
+                    continue
 
-                    merged_schedules = []
-                    for idx, sched in enumerate(schedules_list):
-                        merged_sched = dict(sched) if isinstance(sched, dict) else {}
-                        detail = detail_list[idx] if idx < len(detail_list) else None
-                        if isinstance(detail, dict):
-                            for key in ("startTime", "endTime", "scheduleId", "limit", "days"):
-                                if detail.get(key) is not None:
-                                    merged_sched[key] = detail[key]
-                        merged_schedules.append(merged_sched)
-                    control["schedules"] = merged_schedules
+                merged_schedules = []
+                for idx, sched in enumerate(schedules_list):
+                    merged_sched = dict(sched) if isinstance(sched, dict) else {}
+                    detail = detail_list[idx] if idx < len(detail_list) else None
+                    if isinstance(detail, dict):
+                        for key in ("startTime", "endTime", "scheduleId", "limit", "days"):
+                            if detail.get(key) is not None:
+                                merged_sched[key] = detail[key]
+                    merged_schedules.append(merged_sched)
+                control["schedules"] = merged_schedules
 
-            merged = {
-                "data": inner_data,
-                "schedules": schedule_block,
-                "schedules_raw": schedules,
-            }
-            _LOGGER.debug("[Enphase] Data fetch complete. Keys: %s", list(merged.keys()))
-            return merged
-        except Exception as e:
-            _LOGGER.warning("[Enphase] Coordinator fetch failed: %s", e)
-            raise
+        merged = {
+            "data": inner_data,
+            "schedules": schedule_block,
+            "schedules_raw": schedules,
+        }
+        _LOGGER.debug("[Enphase] Data fetch complete. Keys: %s", list(merged.keys()))
+        return merged
 
-    async def async_force_refresh(self):
+    async def async_force_refresh(self) -> None:
         """Manually triggered refresh (Force Cloud Refresh button)."""
         _LOGGER.info("[Enphase] Manual cloud refresh requested.")
         await self.async_request_refresh()

--- a/custom_components/enphase_envoy_cloud_control/device.py
+++ b/custom_components/enphase_envoy_cloud_control/device.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from .const import DEVICE_KIND_BATTERY, DEVICE_KIND_SCHEDULE_EDITOR, DOMAIN
 
+__all__ = ["battery_device_info", "schedule_editor_device_info"]
+
 
 def battery_device_info(entry_id: str) -> dict:
     """Return device info for the main battery device."""

--- a/custom_components/enphase_envoy_cloud_control/diagnostics.py
+++ b/custom_components/enphase_envoy_cloud_control/diagnostics.py
@@ -1,0 +1,60 @@
+"""Diagnostics support for Enphase Envoy Cloud Control."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+__all__ = ["async_get_config_entry_diagnostics"]
+
+# Anything identifying or secret is redacted from diagnostics downloads.
+TO_REDACT = {
+    "email",
+    "password",
+    "user_id",
+    "battery_id",
+    "userId",
+    "siteId",
+    "scheduleId",
+    "jwt",
+    "xsrf",
+    "cookies",
+    "e-auth-token",
+    "x-xsrf-token",
+}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return redacted diagnostics for a config entry."""
+    entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id, {})
+    coordinator = entry_data.get("coordinator") if isinstance(entry_data, dict) else None
+
+    diagnostics: dict[str, Any] = {
+        "entry": {
+            "data": async_redact_data(dict(entry.data), TO_REDACT),
+            "options": dict(entry.options),
+        },
+    }
+
+    if coordinator is not None:
+        diagnostics["coordinator"] = {
+            "last_update_success": coordinator.last_update_success,
+            "last_successful_poll": str(coordinator.last_successful_poll),
+            "update_interval": str(coordinator.update_interval),
+            "data": async_redact_data(coordinator.data or {}, TO_REDACT),
+        }
+        diagnostics["editor_state"] = {
+            "editor": async_redact_data(
+                dict(entry_data.get("editor") or {}), TO_REDACT
+            ),
+            "new_editor": dict(entry_data.get("new_editor") or {}),
+        }
+
+    return diagnostics

--- a/custom_components/enphase_envoy_cloud_control/editor.py
+++ b/custom_components/enphase_envoy_cloud_control/editor.py
@@ -9,6 +9,19 @@ from typing import Any
 from .const import DOMAIN
 from .coordinator import EnphaseCoordinator
 
+__all__ = [
+    "DAY_KEY_BY_INDEX",
+    "DAY_ORDER",
+    "days_list_from_editor",
+    "default_day_flags",
+    "default_editor_state",
+    "default_new_editor_state",
+    "editor_days_from_list",
+    "get_coordinator",
+    "get_entry_data",
+    "normalize_schedules",
+]
+
 DAY_ORDER: list[tuple[str, int]] = [
     ("mon", 1),
     ("tue", 2),

--- a/custom_components/enphase_envoy_cloud_control/enphase_client.py
+++ b/custom_components/enphase_envoy_cloud_control/enphase_client.py
@@ -1,18 +1,37 @@
+"""Client for the Enphase Enlighten cloud API.
+
+Handles login (email/password -> JWT + XSRF token), token caching and
+refresh, and the battery settings/schedule endpoints used by the
+Battery Profile UI. All methods are synchronous and HA-agnostic; Home
+Assistant callers must run them in an executor.
+"""
+
 from __future__ import annotations
+
 import base64
+import json
 import logging
 import os
-import json
 import re
+from collections.abc import Sequence
 from datetime import datetime, timezone
 from typing import Any
+
 import requests
 
+__all__ = ["AuthError", "EnphaseClient"]
+
 _LOGGER = logging.getLogger(__name__)
+
+# NOTE: the session (and therefore its cookie jar) is module-level and shared
+# across every EnphaseClient instance / config entry. This is a known
+# limitation that prevents true multi-account support.
 SESSION = requests.Session()
 
 CACHE_DIR = os.path.join(os.path.dirname(__file__), ".cache")
 CACHE_FILE = os.path.join(CACHE_DIR, "auth.json")
+
+BATTERY_PROFILE_ORIGIN = "https://battery-profile-ui.enphaseenergy.com"
 
 
 class AuthError(Exception):
@@ -22,7 +41,13 @@ class AuthError(Exception):
 class EnphaseClient:
     """Handles Enphase Cloud authentication and API calls."""
 
-    def __init__(self, email: str, password: str, user_id: str | None, battery_id: str | None):
+    def __init__(
+        self,
+        email: str,
+        password: str,
+        user_id: str | None,
+        battery_id: str | None,
+    ) -> None:
         self.email = email
         self.password = password
         self.user_id = user_id
@@ -36,7 +61,7 @@ class EnphaseClient:
     # CACHE
     # -------------------------------------------------------------------------
 
-    def load_cache(self):
+    def load_cache(self) -> None:
         """Load cached JWT/XSRF tokens if present."""
         try:
             if os.path.exists(CACHE_FILE):
@@ -53,10 +78,10 @@ class EnphaseClient:
                     if isinstance(self.cookies, dict):
                         SESSION.cookies.update(self.cookies)
                     _LOGGER.debug("[Enphase] Loaded cached tokens")
-        except Exception as exc:
+        except (OSError, ValueError, TypeError) as exc:
             _LOGGER.warning("[Enphase] Failed to load cache: %s", exc)
 
-    def _save_cache(self):
+    def _save_cache(self) -> None:
         """Persist JWT/XSRF tokens."""
         try:
             os.makedirs(CACHE_DIR, exist_ok=True)
@@ -71,14 +96,14 @@ class EnphaseClient:
             with open(CACHE_FILE, "w", encoding="utf-8") as f:
                 json.dump(data, f)
             _LOGGER.debug("[Enphase] Cache saved.")
-        except Exception as exc:
+        except (OSError, TypeError) as exc:
             _LOGGER.warning("[Enphase] Failed to save cache: %s", exc)
 
     # -------------------------------------------------------------------------
     # AUTH
     # -------------------------------------------------------------------------
 
-    def _csrf_login_token(self):
+    def _csrf_login_token(self) -> str:
         """Get authenticity_token for login."""
         r = SESSION.get("https://enlighten.enphaseenergy.com/login", timeout=30)
         if not r.ok:
@@ -90,11 +115,12 @@ class EnphaseClient:
             raise AuthError("Could not find authenticity_token on login page.")
         return match.group(1)
 
-    def _login(self):
+    def _login(self) -> None:
         """Perform login to retrieve JWT."""
         if not self.email or not self.password:
             raise AuthError("Email and password are required for login.")
 
+        _LOGGER.debug("[Enphase] Logging in to Enphase Enlighten as %s", self.email)
         SESSION.cookies.clear()
         authenticity = self._csrf_login_token()
         payload = {
@@ -128,21 +154,22 @@ class EnphaseClient:
         self._update_xsrf()
         self._save_cache()
 
-    def _update_xsrf(self):
+    def _update_xsrf(self) -> None:
         """Fetch new XSRF token using JWT."""
         if not self.battery_id or not self.user_id:
             self._discover_ids()
         if not self.battery_id or not self.user_id:
             raise AuthError("Missing battery/user IDs for XSRF request.")
 
+        _LOGGER.debug("[Enphase] Requesting new XSRF token.")
         url = (
             f"https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/"
             f"battery/sites/{self.battery_id}/schedules/isValid"
         )
         headers = {
             "content-type": "application/json",
-            "origin": "https://battery-profile-ui.enphaseenergy.com",
-            "referer": "https://battery-profile-ui.enphaseenergy.com/",
+            "origin": BATTERY_PROFILE_ORIGIN,
+            "referer": f"{BATTERY_PROFILE_ORIGIN}/",
             "e-auth-token": self.jwt_token,
             "username": str(self.user_id),
         }
@@ -164,13 +191,17 @@ class EnphaseClient:
         )
         _LOGGER.debug("[Enphase] XSRF token updated.")
 
-    def _ensure_tokens(self, force_refresh=False):
+    def _ensure_tokens(self, force_refresh: bool = False) -> tuple[str, str]:
         """Ensure JWT/XSRF tokens are present and valid."""
         needs_login = force_refresh or not self._jwt_valid()
         if needs_login or not self._cookies_present():
-            _LOGGER.info("[Enphase] Refreshing authentication tokens.")
+            _LOGGER.info(
+                "[Enphase] Refreshing authentication tokens (force_refresh=%s).",
+                force_refresh,
+            )
             self._login()
         else:
+            _LOGGER.debug("[Enphase] Reusing cached JWT (exp=%s).", self.jwt_exp)
             if not self.user_id or not self.battery_id:
                 self._discover_ids()
 
@@ -224,7 +255,7 @@ class EnphaseClient:
         data = data + ("=" * pad)
         try:
             return base64.b64decode(data).decode("utf-8")
-        except Exception:
+        except (ValueError, UnicodeDecodeError):
             return ""
 
     def _discover_ids(self) -> None:
@@ -267,30 +298,108 @@ class EnphaseClient:
         )
 
     # -------------------------------------------------------------------------
+    # REQUEST HELPERS
+    # -------------------------------------------------------------------------
+
+    def _build_headers(
+        self,
+        jwt: str,
+        xsrf: str,
+        *,
+        include_origin: bool = True,
+        delete_variant: bool = False,
+    ) -> dict[str, str]:
+        """Build the standard API headers.
+
+        ``include_origin=False`` matches the batterySettings GET variant (no
+        origin/referer). ``delete_variant=True`` matches the schedule delete
+        endpoint, which additionally needs accept/user-agent headers and a
+        ``locale=en`` cookie prefix.
+        """
+        headers: dict[str, str] = {
+            "content-type": "application/json",
+            "e-auth-token": jwt,
+            "x-xsrf-token": xsrf,
+            "username": str(self.user_id),
+        }
+        if delete_variant:
+            headers["accept"] = "application/json, text/plain, */*"
+            headers["accept-language"] = "en-GB,en-US;q=0.9,en;q=0.8"
+            headers["user-agent"] = "curl/8.14.1"
+        if include_origin or delete_variant:
+            headers["origin"] = BATTERY_PROFILE_ORIGIN
+            headers["referer"] = f"{BATTERY_PROFILE_ORIGIN}/"
+        headers["cookie"] = (
+            f"locale=en; BP-XSRF-Token={xsrf};"
+            if delete_variant
+            else f"BP-XSRF-Token={xsrf}"
+        )
+        return headers
+
+    def _request_with_retry(
+        self,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        *,
+        json_payload: Any | None = None,
+        context: str = "request",
+        retry_on_403: bool = True,
+    ) -> requests.Response:
+        """Send an API request, refreshing tokens and retrying once on 403.
+
+        Does NOT call ``raise_for_status()`` — callers decide how to handle
+        non-403 errors.
+        """
+        _LOGGER.debug(
+            "[Enphase] %s request: url=%s headers=%s payload=%s",
+            context,
+            url,
+            {k: v for k, v in headers.items() if k != "e-auth-token"},
+            json_payload,
+        )
+        kwargs: dict[str, Any] = {"headers": headers, "timeout": 30}
+        if json_payload is not None:
+            kwargs["json"] = json_payload
+        r = SESSION.request(method, url, **kwargs)
+        _LOGGER.debug(
+            "[Enphase] %s response: status=%s body=%s",
+            context,
+            r.status_code,
+            r.text,
+        )
+        if r.status_code == 403 and retry_on_403:
+            _LOGGER.warning(
+                "[Enphase] 403 on %s – refreshing tokens and retrying.", context
+            )
+            jwt, xsrf = self._ensure_tokens(force_refresh=True)
+            # Only the token headers are refreshed; the cookie header is left
+            # as-is on purpose — the session cookie jar carries the fresh
+            # BP-XSRF-Token (matches the original per-method retry behaviour).
+            headers["e-auth-token"] = jwt
+            headers["x-xsrf-token"] = xsrf
+            r = SESSION.request(method, url, **kwargs)
+            _LOGGER.debug(
+                "[Enphase] %s retry response: status=%s body=%s",
+                context,
+                r.status_code,
+                r.text,
+            )
+        return r
+
+    # -------------------------------------------------------------------------
     # DATA
     # -------------------------------------------------------------------------
 
-    def battery_settings(self):
+    def battery_settings(self) -> dict[str, Any]:
         """Fetch current battery configuration."""
         jwt, xsrf = self._ensure_tokens()
         url = (
             f"https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/"
             f"batterySettings/{self.battery_id}?userId={self.user_id}&source=enho"
         )
-        headers = {
-            "content-type": "application/json",
-            "e-auth-token": jwt,
-            "x-xsrf-token": xsrf,
-            "username": str(self.user_id),
-            "cookie": f"BP-XSRF-Token={xsrf}",
-        }
-        r = SESSION.get(url, headers=headers, timeout=30)
-        if r.status_code == 403:
-            _LOGGER.warning("[Enphase] 403 Forbidden on battery_settings – refreshing XSRF.")
-            jwt, xsrf = self._ensure_tokens(force_refresh=True)
-            headers["e-auth-token"] = jwt
-            headers["x-xsrf-token"] = xsrf
-            r = SESSION.get(url, headers=headers, timeout=30)
+        headers = self._build_headers(jwt, xsrf, include_origin=False)
+        r = self._request_with_retry("GET", url, headers, context="battery_settings")
         r.raise_for_status()
         _LOGGER.debug("[Enphase] Battery settings fetched.")
         return r.json()
@@ -299,7 +408,13 @@ class EnphaseClient:
     # ACTIONS (toggles)
     # -------------------------------------------------------------------------
 
-    def set_mode(self, mode: str, enable: bool, start_time: str | None = None, end_time: str | None = None):
+    def set_mode(
+        self,
+        mode: str,
+        enable: bool,
+        start_time: str | None = None,
+        end_time: str | None = None,
+    ) -> bool:
         """
         Toggle Enphase battery control modes via the cloud API.
 
@@ -314,17 +429,10 @@ class EnphaseClient:
         _LOGGER.info("[Enphase] Setting mode '%s' -> %s", short_mode, enable)
 
         jwt, xsrf = self._ensure_tokens()
-        headers = {
-            "content-type": "application/json",
-            "e-auth-token": jwt,
-            "x-xsrf-token": xsrf,
-            "username": str(self.user_id),
-            "origin": "https://battery-profile-ui.enphaseenergy.com",
-            "referer": "https://battery-profile-ui.enphaseenergy.com/",
-            "cookie": f"BP-XSRF-Token={xsrf}",
-        }
+        headers = self._build_headers(jwt, xsrf)
 
         # Payload mapping for each mode type
+        payload: dict[str, Any]
         if short_mode == "cfg":
             payload = {
                 "chargeFromGrid": enable,
@@ -350,76 +458,53 @@ class EnphaseClient:
             f"batterySettings/{self.battery_id}?userId={self.user_id}&source=enho"
         )
 
-        _LOGGER.debug(
-            "[Enphase] set_mode request: url=%s headers=%s payload=%s",
+        r = self._request_with_retry(
+            "PUT",
             url,
-            {k: v for k, v in headers.items() if k != "e-auth-token"},
-            payload,
+            headers,
+            json_payload=payload,
+            context=f"set_mode({short_mode})",
         )
-        r = SESSION.put(url, json=payload, headers=headers, timeout=30)
-        _LOGGER.debug(
-            "[Enphase] set_mode response: status=%s body=%s",
-            r.status_code,
-            r.text,
-        )
-        if r.status_code == 403:
-            _LOGGER.warning("[Enphase] 403 Forbidden on set_mode(%s) – refreshing XSRF and retrying", short_mode)
-            jwt, xsrf = self._ensure_tokens(force_refresh=True)
-            headers["e-auth-token"] = jwt
-            headers["x-xsrf-token"] = xsrf
-            r = SESSION.put(url, json=payload, headers=headers, timeout=30)
-            _LOGGER.debug(
-                "[Enphase] set_mode retry response: status=%s body=%s",
+
+        if not r.ok:
+            _LOGGER.error(
+                "[Enphase] set_mode(%s) failed: %s %s",
+                short_mode,
                 r.status_code,
                 r.text,
             )
-
-        if not r.ok:
-            _LOGGER.error("[Enphase] set_mode(%s) failed: %s %s", short_mode, r.status_code, r.text)
             r.raise_for_status()
 
-        _LOGGER.info("[Enphase] Mode '%s' set successfully (HTTP %s)", short_mode, r.status_code)
+        _LOGGER.info(
+            "[Enphase] Mode '%s' set successfully (HTTP %s)", short_mode, r.status_code
+        )
         return True
 
     # -------------------------------------------------------------------------
     # SCHEDULE MANAGEMENT
     # -------------------------------------------------------------------------
 
-    def get_schedules(self):
+    def get_schedules(self) -> dict[str, Any]:
         """Return all schedules for this site/battery."""
         jwt, xsrf = self._ensure_tokens()
         url = (
             f"https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/"
             f"battery/sites/{self.battery_id}/schedules"
         )
-        headers = {
-            "content-type": "application/json",
-            "e-auth-token": jwt,
-            "x-xsrf-token": xsrf,
-            "username": str(self.user_id),
-            "origin": "https://battery-profile-ui.enphaseenergy.com",
-            "referer": "https://battery-profile-ui.enphaseenergy.com/",
-            "cookie": f"BP-XSRF-Token={xsrf}",
-        }
-        r = SESSION.get(url, headers=headers, timeout=30)
-        if r.status_code == 403:
-            _LOGGER.warning("[Enphase] 403 on get_schedules – refreshing tokens.")
-            jwt, xsrf = self._ensure_tokens(force_refresh=True)
-            headers["e-auth-token"] = jwt
-            headers["x-xsrf-token"] = xsrf
-            r = SESSION.get(url, headers=headers, timeout=30)
+        headers = self._build_headers(jwt, xsrf)
+        r = self._request_with_retry("GET", url, headers, context="get_schedules")
         r.raise_for_status()
         return r.json()
 
     def add_schedule(
         self,
-        schedule_type,
-        start_time,
-        end_time,
-        limit,
-        days,
-        timezone="UTC",
-    ):
+        schedule_type: str,
+        start_time: str,
+        end_time: str,
+        limit: int | str,
+        days: Sequence[int | str],
+        timezone: str = "UTC",
+    ) -> dict[str, Any]:
         """Add a new schedule entry (mirrors your REST command)."""
         schedule_type = str(schedule_type).upper()
         jwt, xsrf = self._ensure_tokens()
@@ -427,15 +512,7 @@ class EnphaseClient:
             f"https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/"
             f"battery/sites/{self.battery_id}/schedules"
         )
-        headers = {
-            "content-type": "application/json",
-            "e-auth-token": jwt,
-            "x-xsrf-token": xsrf,
-            "username": str(self.user_id),
-            "origin": "https://battery-profile-ui.enphaseenergy.com",
-            "referer": "https://battery-profile-ui.enphaseenergy.com/",
-            "cookie": f"BP-XSRF-Token={xsrf}",
-        }
+        headers = self._build_headers(jwt, xsrf)
         payload = {
             "timezone": timezone or "UTC",
             "startTime": start_time[:5],
@@ -445,78 +522,32 @@ class EnphaseClient:
             "days": [int(d) for d in days],
         }
         _LOGGER.info("[Enphase] Adding schedule: %s", payload)
-        _LOGGER.debug(
-            "[Enphase] add_schedule request: url=%s headers=%s payload=%s",
-            url,
-            {k: v for k, v in headers.items() if k != "e-auth-token"},
-            payload,
+        r = self._request_with_retry(
+            "POST", url, headers, json_payload=payload, context="add_schedule"
         )
-        r = SESSION.post(url, json=payload, headers=headers, timeout=30)
-        _LOGGER.debug(
-            "[Enphase] add_schedule response: status=%s body=%s",
-            r.status_code,
-            r.text,
-        )
-        if r.status_code == 403:
-            jwt, xsrf = self._ensure_tokens(force_refresh=True)
-            headers["e-auth-token"] = jwt
-            headers["x-xsrf-token"] = xsrf
-            r = SESSION.post(url, json=payload, headers=headers, timeout=30)
-            _LOGGER.debug(
-                "[Enphase] add_schedule retry response: status=%s body=%s",
-                r.status_code,
-                r.text,
-            )
         r.raise_for_status()
         _LOGGER.info("[Enphase] Schedule added successfully.")
         return r.json()
 
-    def delete_schedule(self, schedule_id):
+    def delete_schedule(self, schedule_id: str) -> bool:
         """Delete a schedule by ID (mirrors your REST command)."""
         jwt, xsrf = self._ensure_tokens()
         url = (
             f"https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/"
             f"battery/sites/{self.battery_id}/schedules/{schedule_id}/delete"
         )
-        headers = {
-            "accept": "application/json, text/plain, */*",
-            "accept-language": "en-GB,en-US;q=0.9,en;q=0.8",
-            "content-type": "application/json",
-            "e-auth-token": jwt,
-            "x-xsrf-token": xsrf,
-            "username": str(self.user_id),
-            "origin": "https://battery-profile-ui.enphaseenergy.com",
-            "referer": "https://battery-profile-ui.enphaseenergy.com/",
-            "cookie": f"locale=en; BP-XSRF-Token={xsrf};",
-            "user-agent": "curl/8.14.1",
-        }
+        headers = self._build_headers(jwt, xsrf, delete_variant=True)
         _LOGGER.info("[Enphase] Deleting schedule ID %s", schedule_id)
-        _LOGGER.debug(
-            "[Enphase] delete_schedule request: url=%s headers=%s",
-            url,
-            {k: v for k, v in headers.items() if k != "e-auth-token"},
+        r = self._request_with_retry(
+            "POST", url, headers, json_payload={}, context="delete_schedule"
         )
-        r = SESSION.post(url, json={}, headers=headers, timeout=30)
-        _LOGGER.debug(
-            "[Enphase] delete_schedule response: status=%s body=%s",
-            r.status_code,
-            r.text,
-        )
-        if r.status_code == 403:
-            jwt, xsrf = self._ensure_tokens(force_refresh=True)
-            headers["e-auth-token"] = jwt
-            headers["x-xsrf-token"] = xsrf
-            r = SESSION.post(url, json={}, headers=headers, timeout=30)
-            _LOGGER.debug(
-                "[Enphase] delete_schedule retry response: status=%s body=%s",
-                r.status_code,
-                r.text,
-            )
         r.raise_for_status()
         _LOGGER.info("[Enphase] Schedule %s deleted successfully.", schedule_id)
         return True
 
-    def validate_schedule(self, schedule_type="dtg", force_opted=False):
+    def validate_schedule(
+        self, schedule_type: str = "dtg", force_opted: bool = False
+    ) -> dict[str, Any]:
         """Validate schedule feasibility (isValid endpoint)."""
         schedule_type = str(schedule_type).upper()
         jwt, xsrf = self._ensure_tokens()
@@ -524,29 +555,19 @@ class EnphaseClient:
             f"https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/"
             f"battery/sites/{self.battery_id}/schedules/isValid"
         )
-        payload = {"scheduleType": schedule_type}
+        payload: dict[str, Any] = {"scheduleType": schedule_type}
         if schedule_type == "CFG" and force_opted:
             payload["forceScheduleOpted"] = True
-        headers = {
-            "content-type": "application/json",
-            "e-auth-token": jwt,
-            "x-xsrf-token": xsrf,
-            "username": str(self.user_id),
-            "origin": "https://battery-profile-ui.enphaseenergy.com",
-            "referer": "https://battery-profile-ui.enphaseenergy.com/",
-            "cookie": f"BP-XSRF-Token={xsrf}",
-        }
-        _LOGGER.debug(
-            "[Enphase] validate_schedule request: url=%s headers=%s payload=%s",
+        headers = self._build_headers(jwt, xsrf)
+        # NOTE: no 403 retry here — the isValid endpoint is itself part of the
+        # XSRF refresh flow (see _update_xsrf), matching original behaviour.
+        r = self._request_with_retry(
+            "POST",
             url,
-            {k: v for k, v in headers.items() if k != "e-auth-token"},
-            payload,
-        )
-        r = SESSION.post(url, json=payload, headers=headers, timeout=30)
-        _LOGGER.debug(
-            "[Enphase] validate_schedule response: status=%s body=%s",
-            r.status_code,
-            r.text,
+            headers,
+            json_payload=payload,
+            context="validate_schedule",
+            retry_on_403=False,
         )
         r.raise_for_status()
         return r.json()
@@ -555,7 +576,7 @@ class EnphaseClient:
     # UTILS
     # -------------------------------------------------------------------------
 
-    def _now_iso(self):
+    def _now_iso(self) -> str:
         """Return current UTC time in ISO format (milliseconds precision)."""
         return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
 

--- a/custom_components/enphase_envoy_cloud_control/enphase_client.py
+++ b/custom_components/enphase_envoy_cloud_control/enphase_client.py
@@ -23,13 +23,9 @@ __all__ = ["AuthError", "EnphaseClient"]
 
 _LOGGER = logging.getLogger(__name__)
 
-# NOTE: the session (and therefore its cookie jar) is module-level and shared
-# across every EnphaseClient instance / config entry. This is a known
-# limitation that prevents true multi-account support.
-SESSION = requests.Session()
-
 CACHE_DIR = os.path.join(os.path.dirname(__file__), ".cache")
-CACHE_FILE = os.path.join(CACHE_DIR, "auth.json")
+# Legacy single-account cache location (pre per-entry caches).
+LEGACY_CACHE_FILE = os.path.join(CACHE_DIR, "auth.json")
 
 BATTERY_PROFILE_ORIGIN = "https://battery-profile-ui.enphaseenergy.com"
 
@@ -47,6 +43,8 @@ class EnphaseClient:
         password: str,
         user_id: str | None,
         battery_id: str | None,
+        cache_key: str | None = None,
+        persist_cache: bool = True,
     ) -> None:
         self.email = email
         self.password = password
@@ -56,6 +54,15 @@ class EnphaseClient:
         self.xsrf_token: str | None = None
         self.cookies: dict | None = None
         self.jwt_exp: int | None = None
+        # Each client owns its session/cookie jar so multiple config entries
+        # (accounts) no longer clobber each other's authentication state.
+        self._session = requests.Session()
+        self._persist_cache = persist_cache
+        if cache_key:
+            safe_key = re.sub(r"[^0-9A-Za-z_-]", "_", cache_key)
+            self._cache_file = os.path.join(CACHE_DIR, f"auth_{safe_key}.json")
+        else:
+            self._cache_file = LEGACY_CACHE_FILE
 
     # -------------------------------------------------------------------------
     # CACHE
@@ -64,9 +71,20 @@ class EnphaseClient:
     def load_cache(self) -> None:
         """Load cached JWT/XSRF tokens if present."""
         try:
-            if os.path.exists(CACHE_FILE):
-                with open(CACHE_FILE, "r", encoding="utf-8") as f:
+            cache_path = self._cache_file
+            if not os.path.exists(cache_path) and os.path.exists(LEGACY_CACHE_FILE):
+                # One-time migration from the pre-multi-account cache file.
+                cache_path = LEGACY_CACHE_FILE
+            if os.path.exists(cache_path):
+                with open(cache_path, "r", encoding="utf-8") as f:
                     data = json.load(f)
+                    # Never adopt another account's cached tokens.
+                    cached_email = data.get("email")
+                    if cached_email and cached_email != self.email:
+                        _LOGGER.debug(
+                            "[Enphase] Ignoring cached tokens for other account."
+                        )
+                        return
                     self.jwt_token = data.get("jwt")
                     self.xsrf_token = data.get("xsrf")
                     self.cookies = data.get("cookies")
@@ -76,24 +94,27 @@ class EnphaseClient:
                     if not self.battery_id:
                         self.battery_id = data.get("battery_id")
                     if isinstance(self.cookies, dict):
-                        SESSION.cookies.update(self.cookies)
+                        self._session.cookies.update(self.cookies)
                     _LOGGER.debug("[Enphase] Loaded cached tokens")
         except (OSError, ValueError, TypeError) as exc:
             _LOGGER.warning("[Enphase] Failed to load cache: %s", exc)
 
     def _save_cache(self) -> None:
         """Persist JWT/XSRF tokens."""
+        if not self._persist_cache:
+            return
         try:
             os.makedirs(CACHE_DIR, exist_ok=True)
             data = {
+                "email": self.email,
                 "jwt": self.jwt_token,
                 "xsrf": self.xsrf_token,
-                "cookies": requests.utils.dict_from_cookiejar(SESSION.cookies),
+                "cookies": requests.utils.dict_from_cookiejar(self._session.cookies),
                 "jwt_exp": self.jwt_exp,
                 "user_id": self.user_id,
                 "battery_id": self.battery_id,
             }
-            with open(CACHE_FILE, "w", encoding="utf-8") as f:
+            with open(self._cache_file, "w", encoding="utf-8") as f:
                 json.dump(data, f)
             _LOGGER.debug("[Enphase] Cache saved.")
         except (OSError, TypeError) as exc:
@@ -105,7 +126,7 @@ class EnphaseClient:
 
     def _csrf_login_token(self) -> str:
         """Get authenticity_token for login."""
-        r = SESSION.get("https://enlighten.enphaseenergy.com/login", timeout=30)
+        r = self._session.get("https://enlighten.enphaseenergy.com/login", timeout=30)
         if not r.ok:
             raise AuthError("Failed to access login page.")
         match = re.search(
@@ -121,7 +142,7 @@ class EnphaseClient:
             raise AuthError("Email and password are required for login.")
 
         _LOGGER.debug("[Enphase] Logging in to Enphase Enlighten as %s", self.email)
-        SESSION.cookies.clear()
+        self._session.cookies.clear()
         authenticity = self._csrf_login_token()
         payload = {
             "utf8": "✓",
@@ -130,7 +151,7 @@ class EnphaseClient:
             "user[password]": self.password,
         }
 
-        r = SESSION.post(
+        r = self._session.post(
             "https://enlighten.enphaseenergy.com/login/login",
             data=payload,
             timeout=30,
@@ -138,7 +159,7 @@ class EnphaseClient:
         if not r.ok:
             raise AuthError("Login failed.")
 
-        jwt_resp = SESSION.get(
+        jwt_resp = self._session.get(
             "https://enlighten.enphaseenergy.com/app-api/jwt_token.json", timeout=30
         )
         jwt_json = jwt_resp.json()
@@ -174,16 +195,16 @@ class EnphaseClient:
             "username": str(self.user_id),
         }
         payload = {"scheduleType": "dtg"}
-        r = SESSION.post(url, json=payload, headers=headers, timeout=30)
-        if "BP-XSRF-Token" in SESSION.cookies:
-            self.xsrf_token = SESSION.cookies["BP-XSRF-Token"]
+        r = self._session.post(url, json=payload, headers=headers, timeout=30)
+        if "BP-XSRF-Token" in self._session.cookies:
+            self.xsrf_token = self._session.cookies["BP-XSRF-Token"]
         if not self.xsrf_token and "BP-XSRF-Token" in r.headers.get("Set-Cookie", ""):
             match = re.search(r"BP-XSRF-Token=([^;]+)", r.headers["Set-Cookie"])
             if match:
                 self.xsrf_token = match.group(1)
         if not self.xsrf_token:
             raise AuthError("Failed to retrieve XSRF token.")
-        SESSION.cookies.set(
+        self._session.cookies.set(
             "BP-XSRF-Token",
             self.xsrf_token,
             domain="enlighten.enphaseenergy.com",
@@ -217,7 +238,7 @@ class EnphaseClient:
         return {"user_id": self.user_id, "battery_id": self.battery_id}
 
     def _cookies_present(self) -> bool:
-        return bool(SESSION.cookies)
+        return bool(self._session.cookies)
 
     def _jwt_valid(self) -> bool:
         if not self.jwt_token:
@@ -260,7 +281,7 @@ class EnphaseClient:
 
     def _discover_ids(self) -> None:
         """Auto-discover numeric battery/site ID and user ID."""
-        final_url = SESSION.get(
+        final_url = self._session.get(
             "https://enlighten.enphaseenergy.com/",
             timeout=30,
             allow_redirects=True,
@@ -275,7 +296,7 @@ class EnphaseClient:
             "https://enlighten.enphaseenergy.com/app-api/"
             f"{site_id}/data.json?app=1&device_status=non_retired&is_mobile=0"
         )
-        app_data = SESSION.get(app_url, timeout=30).json()
+        app_data = self._session.get(app_url, timeout=30).json()
         app_block = app_data.get("app", {})
         user_id = (
             app_block.get("userId")
@@ -361,7 +382,7 @@ class EnphaseClient:
         kwargs: dict[str, Any] = {"headers": headers, "timeout": 30}
         if json_payload is not None:
             kwargs["json"] = json_payload
-        r = SESSION.request(method, url, **kwargs)
+        r = self._session.request(method, url, **kwargs)
         _LOGGER.debug(
             "[Enphase] %s response: status=%s body=%s",
             context,
@@ -378,7 +399,7 @@ class EnphaseClient:
             # BP-XSRF-Token (matches the original per-method retry behaviour).
             headers["e-auth-token"] = jwt
             headers["x-xsrf-token"] = xsrf
-            r = SESSION.request(method, url, **kwargs)
+            r = self._session.request(method, url, **kwargs)
             _LOGGER.debug(
                 "[Enphase] %s retry response: status=%s body=%s",
                 context,

--- a/custom_components/enphase_envoy_cloud_control/manifest.json
+++ b/custom_components/enphase_envoy_cloud_control/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "enphase_envoy_cloud_control",
   "name": "Enphase Envoy Cloud Control",
-  "version": "0.1",
+  "version": "1.6.0",
   "documentation": "https://github.com/chinedu40/hacs_enphase_envoy_cloud",
   "dependencies": [],
   "codeowners": ["@chinedu40"],

--- a/custom_components/enphase_envoy_cloud_control/manifest.json
+++ b/custom_components/enphase_envoy_cloud_control/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "enphase_envoy_cloud_control",
   "name": "Enphase Envoy Cloud Control",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "documentation": "https://github.com/chinedu40/hacs_enphase_envoy_cloud",
   "dependencies": [],
   "codeowners": ["@chinedu40"],

--- a/custom_components/enphase_envoy_cloud_control/number.py
+++ b/custom_components/enphase_envoy_cloud_control/number.py
@@ -2,14 +2,24 @@
 
 from __future__ import annotations
 
-from homeassistant.components.number import NumberEntity
+from typing import Any
 
-from .const import DOMAIN
+from homeassistant.components.number import NumberEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
 from .device import schedule_editor_device_info
 from .editor import get_entry_data
 
+__all__ = ["EnphaseScheduleLimit", "async_setup_entry"]
 
-async def async_setup_entry(hass, entry, async_add_entities):
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Set up schedule number entities."""
     async_add_entities(
         [
@@ -28,7 +38,7 @@ class EnphaseScheduleLimit(NumberEntity):
     _attr_native_step = 1
     _attr_native_unit_of_measurement = "%"
 
-    def __init__(self, entry_id: str, is_new: bool):
+    def __init__(self, entry_id: str, is_new: bool) -> None:
         self.entry_id = entry_id
         self.is_new = is_new
         schedule_label = "New Schedule" if is_new else "Schedule"
@@ -49,5 +59,5 @@ class EnphaseScheduleLimit(NumberEntity):
         self.async_write_ha_state()
 
     @property
-    def device_info(self):
+    def device_info(self) -> dict[str, Any]:
         return schedule_editor_device_info(self.entry_id)

--- a/custom_components/enphase_envoy_cloud_control/options_flow.py
+++ b/custom_components/enphase_envoy_cloud_control/options_flow.py
@@ -1,13 +1,21 @@
+"""Options flow: polling/notification settings and schedule add/delete forms."""
+
 from __future__ import annotations
+
+from typing import Any
 
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.components import persistent_notification
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import selector
 
 from .const import DEFAULT_POLL_INTERVAL, DOMAIN
 from .const import LOGGER as _LOGGER
+
+__all__ = ["EnphaseOptionsFlowHandler"]
 
 SERVICE_ADD_SCHEDULE = "add_schedule"
 SERVICE_DELETE_SCHEDULE = "delete_schedule"
@@ -16,11 +24,13 @@ SERVICE_DELETE_SCHEDULE = "delete_schedule"
 class EnphaseOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle options for Enphase Envoy Cloud Control."""
 
-    def __init__(self, config_entry: config_entries.ConfigEntry):
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         self._config_entry = config_entry
         self._last_error: str | None = None
 
-    async def async_step_init(self, user_input=None):
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Manage the Enphase options."""
         source = self.context.get("source")
         _LOGGER.debug(
@@ -59,7 +69,9 @@ class EnphaseOptionsFlowHandler(config_entries.OptionsFlow):
             description_placeholders={"interval": DEFAULT_POLL_INTERVAL},
         )
 
-    async def async_step_schedule_add(self, user_input=None):
+    async def async_step_schedule_add(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Interactive form for adding a schedule via the options flow."""
         _LOGGER.debug(
             "[Enphase] Options flow schedule_add: user_input=%s",
@@ -92,7 +104,8 @@ class EnphaseOptionsFlowHandler(config_entries.OptionsFlow):
                 except HomeAssistantError as err:
                     self._last_error = str(err)
                     errors["base"] = "service_error"
-                    self.hass.components.persistent_notification.async_create(
+                    persistent_notification.async_create(
+                        self.hass,
                         f"⚠️ Failed to add schedule: {self._last_error}",
                         title="Enphase Envoy Cloud Control",
                         notification_id=f"{DOMAIN}_schedule_add_error",
@@ -151,7 +164,9 @@ class EnphaseOptionsFlowHandler(config_entries.OptionsFlow):
             description_placeholders=description_placeholders,
         )
 
-    async def async_step_schedule_delete(self, user_input=None):
+    async def async_step_schedule_delete(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Interactive form for deleting a schedule via the options flow."""
         _LOGGER.debug(
             "[Enphase] Options flow schedule_delete: user_input=%s",
@@ -163,7 +178,8 @@ class EnphaseOptionsFlowHandler(config_entries.OptionsFlow):
 
         options = self._schedule_options()
         if not options:
-            self.hass.components.persistent_notification.async_create(
+            persistent_notification.async_create(
+                self.hass,
                 "⚠️ No schedules available to delete.",
                 title="Enphase Envoy Cloud Control",
                 notification_id=f"{DOMAIN}_schedule_delete_error",
@@ -189,7 +205,8 @@ class EnphaseOptionsFlowHandler(config_entries.OptionsFlow):
                 except HomeAssistantError as err:
                     self._last_error = str(err)
                     errors["base"] = "service_error"
-                    self.hass.components.persistent_notification.async_create(
+                    persistent_notification.async_create(
+                        self.hass,
                         f"⚠️ Failed to delete schedule: {self._last_error}",
                         title="Enphase Envoy Cloud Control",
                         notification_id=f"{DOMAIN}_schedule_delete_error",

--- a/custom_components/enphase_envoy_cloud_control/select.py
+++ b/custom_components/enphase_envoy_cloud_control/select.py
@@ -23,6 +23,8 @@ __all__ = ["EnphaseNewScheduleTypeSelect", "EnphaseScheduleSelect", "async_setup
 
 _LOGGER = logging.getLogger(__name__)
 
+DAY_LABELS = {1: "Mon", 2: "Tue", 3: "Wed", 4: "Thu", 5: "Fri", 6: "Sat", 7: "Sun"}
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -41,7 +43,12 @@ async def async_setup_entry(
 
 
 class EnphaseScheduleSelect(SelectEntity):
-    """Select the active schedule to edit."""
+    """Select the active schedule to edit.
+
+    Options are human-readable labels (type, time range, days, limit); the
+    underlying schedule UUID is kept in the editor state and exposed via the
+    ``schedule_id`` attribute.
+    """
 
     _attr_name = "Enphase Schedule Selected"
     _attr_icon = "mdi:calendar-edit"
@@ -51,28 +58,71 @@ class EnphaseScheduleSelect(SelectEntity):
         self.entry_id = entry_id
         self._attr_unique_id = f"{entry_id}_schedule_selected"
 
+    @staticmethod
+    def _label_for(schedule: dict[str, Any]) -> str:
+        """Build a readable label like 'CFG 02:00–06:00 · Mon, Tue · 80%'."""
+        days = schedule.get("days") or []
+        day_str = ", ".join(DAY_LABELS[d] for d in days if d in DAY_LABELS) or "no days"
+        return (
+            f"{str(schedule.get('type', '?')).upper()} "
+            f"{schedule.get('start', '??')}–{schedule.get('end', '??')} "
+            f"· {day_str} · {schedule.get('limit', 0)}%"
+        )
+
+    def _labelled_schedules(self) -> list[tuple[str, dict[str, Any]]]:
+        """Return (label, schedule) pairs with duplicate labels disambiguated."""
+        pairs: list[tuple[str, dict[str, Any]]] = []
+        seen: set[str] = set()
+        for schedule in normalize_schedules(self.coordinator):
+            label = self._label_for(schedule)
+            if label in seen:
+                label = f"{label} · #{str(schedule['id'])[:8]}"
+            seen.add(label)
+            pairs.append((label, schedule))
+        return pairs
+
     @property
     def options(self) -> list[str]:
-        schedules = normalize_schedules(self.coordinator)
-        return [schedule["id"] for schedule in schedules]
+        return [label for label, _ in self._labelled_schedules()]
 
     @property
     def current_option(self) -> str | None:
         editor = get_entry_data(self.hass, self.entry_id)["editor"]
-        return editor.get("selected_schedule_id")
+        selected_id = editor.get("selected_schedule_id")
+        if not selected_id:
+            return None
+        return next(
+            (
+                label
+                for label, schedule in self._labelled_schedules()
+                if schedule["id"] == selected_id
+            ),
+            None,
+        )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        editor = get_entry_data(self.hass, self.entry_id)["editor"]
+        return {"schedule_id": editor.get("selected_schedule_id")}
 
     async def async_select_option(self, option: str) -> None:
-        entry_data = get_entry_data(self.hass, self.entry_id)
-        schedules = normalize_schedules(self.coordinator)
-        match = next((sched for sched in schedules if sched["id"] == option), None)
-        editor = entry_data["editor"]
-        editor["selected_schedule_id"] = option
-        if match:
-            editor["schedule_type"] = match.get("type", "cfg")
-            editor["start_time"] = match.get("start", "00:00")
-            editor["end_time"] = match.get("end", "00:00")
-            editor["limit"] = int(match.get("limit", 0))
-            editor["days"] = editor_days_from_list(match.get("days", []))
+        match: dict[str, Any] | None = None
+        for label, schedule in self._labelled_schedules():
+            # Match by display label, but also accept a raw schedule ID so
+            # existing automations/scripts that pass UUIDs keep working.
+            if option in (label, schedule["id"]):
+                match = schedule
+                break
+        if match is None:
+            _LOGGER.warning("[Enphase] Unknown schedule selected: %s", option)
+            return
+        editor = get_entry_data(self.hass, self.entry_id)["editor"]
+        editor["selected_schedule_id"] = match["id"]
+        editor["schedule_type"] = match.get("type", "cfg")
+        editor["start_time"] = match.get("start", "00:00")
+        editor["end_time"] = match.get("end", "00:00")
+        editor["limit"] = int(match.get("limit", 0))
+        editor["days"] = editor_days_from_list(match.get("days", []))
         self.async_write_ha_state()
 
     @property

--- a/custom_components/enphase_envoy_cloud_control/select.py
+++ b/custom_components/enphase_envoy_cloud_control/select.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .coordinator import EnphaseCoordinator
 from .device import schedule_editor_device_info
 from .editor import (
     editor_days_from_list,
@@ -15,10 +19,16 @@ from .editor import (
     normalize_schedules,
 )
 
+__all__ = ["EnphaseNewScheduleTypeSelect", "EnphaseScheduleSelect", "async_setup_entry"]
+
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass, entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Set up schedule select entities."""
     coordinator = get_coordinator(hass, entry.entry_id)
     async_add_entities(
@@ -36,18 +46,18 @@ class EnphaseScheduleSelect(SelectEntity):
     _attr_name = "Enphase Schedule Selected"
     _attr_icon = "mdi:calendar-edit"
 
-    def __init__(self, coordinator, entry_id: str):
+    def __init__(self, coordinator: EnphaseCoordinator, entry_id: str) -> None:
         self.coordinator = coordinator
         self.entry_id = entry_id
         self._attr_unique_id = f"{entry_id}_schedule_selected"
 
     @property
-    def options(self):
+    def options(self) -> list[str]:
         schedules = normalize_schedules(self.coordinator)
         return [schedule["id"] for schedule in schedules]
 
     @property
-    def current_option(self):
+    def current_option(self) -> str | None:
         editor = get_entry_data(self.hass, self.entry_id)["editor"]
         return editor.get("selected_schedule_id")
 
@@ -66,7 +76,7 @@ class EnphaseScheduleSelect(SelectEntity):
         self.async_write_ha_state()
 
     @property
-    def device_info(self):
+    def device_info(self) -> dict[str, Any]:
         return schedule_editor_device_info(self.entry_id)
 
 
@@ -76,17 +86,17 @@ class EnphaseNewScheduleTypeSelect(SelectEntity):
     _attr_name = "Enphase New Schedule Type"
     _attr_icon = "mdi:calendar-plus"
 
-    def __init__(self, entry_id: str):
+    def __init__(self, entry_id: str) -> None:
         self.entry_id = entry_id
         self._attr_unique_id = f"{entry_id}_new_schedule_type"
         self._attr_options = ["cfg", "dtg", "rbd"]
 
     @property
-    def options(self):
+    def options(self) -> list[str]:
         return list(self._attr_options)
 
     @property
-    def current_option(self):
+    def current_option(self) -> str | None:
         entry_data = get_entry_data(self.hass, self.entry_id)
         return entry_data["new_editor"].get("schedule_type", "cfg")
 
@@ -99,5 +109,5 @@ class EnphaseNewScheduleTypeSelect(SelectEntity):
         self.async_write_ha_state()
 
     @property
-    def device_info(self):
+    def device_info(self) -> dict[str, Any]:
         return schedule_editor_device_info(self.entry_id)

--- a/custom_components/enphase_envoy_cloud_control/sensor.py
+++ b/custom_components/enphase_envoy_cloud_control/sensor.py
@@ -22,12 +22,47 @@ from .enphase_client import AuthError
 
 __all__ = [
     "EnphaseBatteryModesSensor",
+    "EnphaseBatterySettingSensor",
     "EnphaseScheduleSensor",
     "EnphaseSchedulesSummarySensor",
     "async_setup_entry",
 ]
 
 _LOGGER = logging.getLogger(__name__)
+
+# Read-only scalar fields from the batterySettings payload, exposed as sensors
+# when the cloud reports them for this system:
+# (payload key, name, unique_id suffix, icon, unit)
+SETTING_SENSORS: list[tuple[str, str, str, str, str | None]] = [
+    (
+        "batteryBackupPercentage",
+        "Enphase Battery Reserve",
+        "battery_reserve",
+        "mdi:battery-arrow-down",
+        "%",
+    ),
+    (
+        "profile",
+        "Enphase Battery Profile",
+        "battery_profile",
+        "mdi:home-battery",
+        None,
+    ),
+    (
+        "batteryGridMode",
+        "Enphase Battery Grid Mode",
+        "battery_grid_mode",
+        "mdi:transmission-tower",
+        None,
+    ),
+    (
+        "veryLowSoc",
+        "Enphase Battery Very Low SoC",
+        "battery_very_low_soc",
+        "mdi:battery-alert",
+        "%",
+    ),
+]
 
 
 async def async_setup_entry(
@@ -37,13 +72,65 @@ async def async_setup_entry(
 ) -> None:
     """Set up Enphase sensors from a config entry."""
     coordinator = get_coordinator(hass, entry.entry_id)
-    sensors = [EnphaseBatteryModesSensor(coordinator), EnphaseSchedulesSummarySensor(coordinator)]
+    sensors: list[SensorEntity] = [
+        EnphaseBatteryModesSensor(coordinator),
+        EnphaseSchedulesSummarySensor(coordinator),
+    ]
 
     # Add per-mode schedule sensors
     for mode in ["cfg", "dtg", "rbd"]:
         sensors.append(EnphaseScheduleSensor(coordinator, mode))
 
+    # Add read-only setting sensors for fields this system actually reports.
+    inner = (coordinator.data or {}).get("data", {})
+    if isinstance(inner, dict):
+        for key, name, suffix, icon, unit in SETTING_SENSORS:
+            if key in inner:
+                sensors.append(
+                    EnphaseBatterySettingSensor(
+                        coordinator, key, name, suffix, icon, unit
+                    )
+                )
+            else:
+                _LOGGER.debug(
+                    "[Enphase] Skipping %s sensor; '%s' not in battery settings.",
+                    name,
+                    key,
+                )
+
     async_add_entities(sensors, True)
+
+
+class EnphaseBatterySettingSensor(CoordinatorEntity, SensorEntity):
+    """Read-only sensor for a scalar field of the batterySettings payload."""
+
+    def __init__(
+        self,
+        coordinator: EnphaseCoordinator,
+        key: str,
+        name: str,
+        unique_suffix: str,
+        icon: str,
+        unit: str | None,
+    ) -> None:
+        super().__init__(coordinator)
+        self._key = key
+        self._attr_name = name
+        self._attr_unique_id = f"{coordinator.entry.entry_id}_{unique_suffix}"
+        self._attr_icon = icon
+        if unit:
+            self._attr_native_unit_of_measurement = unit
+
+    @property
+    def native_value(self) -> Any:
+        inner = (self.coordinator.data or {}).get("data", {})
+        if not isinstance(inner, dict):
+            return None
+        return inner.get(self._key)
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        return battery_device_info(self.coordinator.entry.entry_id)
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/enphase_envoy_cloud_control/sensor.py
+++ b/custom_components/enphase_envoy_cloud_control/sensor.py
@@ -1,17 +1,40 @@
+"""Sensors exposing Enphase battery mode state and schedule summaries."""
+
 from __future__ import annotations
+
 import logging
 from datetime import datetime, timezone
+from typing import Any
+
+import requests
+
 from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers.entity import EntityCategory
-from .const import DOMAIN
+
+from .coordinator import EnphaseCoordinator
 from .device import battery_device_info
 from .editor import normalize_schedules, get_coordinator
+from .enphase_client import AuthError
+
+__all__ = [
+    "EnphaseBatteryModesSensor",
+    "EnphaseScheduleSensor",
+    "EnphaseSchedulesSummarySensor",
+    "async_setup_entry",
+]
 
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass, entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Set up Enphase sensors from a config entry."""
     coordinator = get_coordinator(hass, entry.entry_id)
     sensors = [EnphaseBatteryModesSensor(coordinator), EnphaseSchedulesSummarySensor(coordinator)]
@@ -35,18 +58,17 @@ class EnphaseBatteryModesSensor(CoordinatorEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.ENUM
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
-    def __init__(self, coordinator):
+    def __init__(self, coordinator: EnphaseCoordinator) -> None:
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.entry.entry_id}_battery_modes"
 
     @property
-    def state(self):
+    def state(self) -> str:
         """Return basic status."""
         return "OK" if self.coordinator.data else "Unavailable"
 
-
     @property
-    def extra_state_attributes(self):
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Expose detailed diagnostic data and timing."""
         try:
             data = self.coordinator.data or {}
@@ -89,12 +111,12 @@ class EnphaseBatteryModesSensor(CoordinatorEntity, SensorEntity):
                     attrs["last_successful_poll"] = t.strftime("%Y-%m-%dT%H:%M:%S%z")
 
             return attrs
-        except Exception as exc:
+        except (AttributeError, KeyError, TypeError, ValueError, IndexError) as exc:
             _LOGGER.warning("Error parsing battery modes attributes: %s", exc)
             return {"error": str(exc)}
 
     @property
-    def device_info(self):
+    def device_info(self) -> dict[str, Any]:
         """Ensure the sensor is attached to the shared Enphase device."""
         return battery_device_info(self.coordinator.entry.entry_id)
 
@@ -106,17 +128,17 @@ class EnphaseSchedulesSummarySensor(CoordinatorEntity, SensorEntity):
     _attr_icon = "mdi:calendar-multiple"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
-    def __init__(self, coordinator):
+    def __init__(self, coordinator: EnphaseCoordinator) -> None:
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.entry.entry_id}_schedules_summary"
 
     @property
-    def state(self):
+    def state(self) -> str:
         schedules = normalize_schedules(self.coordinator)
         return str(len(schedules))
 
     @property
-    def extra_state_attributes(self):
+    def extra_state_attributes(self) -> dict[str, Any]:
         attrs = {
             "schedules": normalize_schedules(self.coordinator),
             "last_refresh": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S%z"),
@@ -128,46 +150,8 @@ class EnphaseSchedulesSummarySensor(CoordinatorEntity, SensorEntity):
         return attrs
 
     @property
-    def device_info(self):
+    def device_info(self) -> dict[str, Any]:
         return battery_device_info(self.coordinator.entry.entry_id)
-
-
-class EnphaseSchedulesSummarySensor(CoordinatorEntity, SensorEntity):
-    """Normalized schedule list for editor usage."""
-
-    _attr_name = "Enphase Schedules Summary"
-    _attr_icon = "mdi:calendar-multiple"
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
-
-    def __init__(self, coordinator):
-        super().__init__(coordinator)
-        self._attr_unique_id = f"{coordinator.entry.entry_id}_schedules_summary"
-
-    @property
-    def state(self):
-        schedules = normalize_schedules(self.coordinator)
-        return str(len(schedules))
-
-    @property
-    def extra_state_attributes(self):
-        attrs = {
-            "schedules": normalize_schedules(self.coordinator),
-            "last_refresh": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S%z"),
-        }
-        if getattr(self.coordinator, "last_update_success_time", None):
-            t = self.coordinator.last_update_success_time
-            if isinstance(t, datetime):
-                attrs["last_successful_poll"] = t.strftime("%Y-%m-%dT%H:%M:%S%z")
-        return attrs
-
-    @property
-    def device_info(self):
-        return {
-            "identifiers": {(DOMAIN, self.coordinator.entry.entry_id)},
-            "name": "Enphase Envoy Cloud Control",
-            "manufacturer": "Enphase Energy",
-            "model": "Envoy Cloud API",
-        }
 
 
 # ---------------------------------------------------------------------------
@@ -179,14 +163,14 @@ class EnphaseScheduleSensor(CoordinatorEntity, SensorEntity):
 
     _attr_icon = "mdi:calendar-clock"
 
-    def __init__(self, coordinator, mode: str):
+    def __init__(self, coordinator: EnphaseCoordinator, mode: str) -> None:
         super().__init__(coordinator)
         self.mode = mode  # cfg | dtg | rbd
         self._attr_name = f"Enphase {mode.upper()} Schedule"
         self._attr_unique_id = f"{coordinator.entry.entry_id}_{mode}_schedule"
 
     @property
-    def state(self):
+    def state(self) -> str:
         """Readable summary like '21:30–03:30, 05:00–06:00'."""
         scheds = self._schedules()
         if not scheds:
@@ -201,7 +185,7 @@ class EnphaseScheduleSensor(CoordinatorEntity, SensorEntity):
         return ", ".join(state_parts)
 
     @property
-    def extra_state_attributes(self):
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Expose full schedule details with IDs."""
         attrs = {"schedules": self._schedules()}
         # Include metadata for clarity
@@ -218,7 +202,7 @@ class EnphaseScheduleSensor(CoordinatorEntity, SensorEntity):
     # ---------------------------------------------------------------------
     # Async-safe schedule fetching with caching
     # ---------------------------------------------------------------------
-    async def _async_fetch_schedules_safe(self):
+    async def _async_fetch_schedules_safe(self) -> dict[str, Any]:
         """Fetch schedules via executor to avoid blocking."""
         try:
             schedules = await self.coordinator.hass.async_add_executor_job(
@@ -227,11 +211,11 @@ class EnphaseScheduleSensor(CoordinatorEntity, SensorEntity):
             # Cache for reuse across sensors
             self.coordinator.client._last_schedules = schedules
             return schedules
-        except Exception as e:
+        except (AuthError, requests.RequestException, ValueError) as e:
             _LOGGER.warning("Async fetch failed for %s schedules: %s", self.mode, e)
             return {}
 
-    def _schedules(self):
+    def _schedules(self) -> list[dict[str, Any]]:
         """Return current schedules for this mode."""
         try:
             data_root = self.coordinator.data or {}
@@ -288,11 +272,11 @@ class EnphaseScheduleSensor(CoordinatorEntity, SensorEntity):
                     if isinstance(m, list):
                         return m
             return []
-        except Exception as e:
+        except (AttributeError, KeyError, TypeError, ValueError, IndexError) as e:
             _LOGGER.warning("Failed to extract %s schedules: %s", self.mode, e)
             return []
 
     @property
-    def device_info(self):
+    def device_info(self) -> dict[str, Any]:
         """Ensure this sensor attaches to the same device as toggles."""
         return battery_device_info(self.coordinator.entry.entry_id)

--- a/custom_components/enphase_envoy_cloud_control/strings.json
+++ b/custom_components/enphase_envoy_cloud_control/strings.json
@@ -12,13 +12,24 @@
           "email": "The email address of your Enphase Enlighten account.",
           "password": "The password of your Enphase Enlighten account."
         }
+      },
+      "reauth_confirm": {
+        "title": "Reauthenticate Enphase Enlighten",
+        "description": "The stored credentials for {email} no longer work. Enter the current password to reconnect.",
+        "data": {
+          "password": "Password"
+        }
       }
     },
     "error": {
-      "missing_credentials": "Email and password are required."
+      "missing_credentials": "Email and password are required.",
+      "invalid_auth": "Authentication failed. Check the email and password (and that the account can access a battery system).",
+      "cannot_connect": "Could not reach the Enphase cloud. Check your connection and try again."
     },
     "abort": {
-      "already_configured": "Account is already configured"
+      "already_configured": "Account is already configured",
+      "reauth_successful": "Reauthentication was successful.",
+      "reauth_failed": "Reauthentication failed: the config entry no longer exists."
     }
   },
   "options": {

--- a/custom_components/enphase_envoy_cloud_control/strings.json
+++ b/custom_components/enphase_envoy_cloud_control/strings.json
@@ -1,0 +1,62 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connect to Enphase Enlighten",
+        "description": "Enter your Enphase Enlighten cloud account credentials.",
+        "data": {
+          "email": "Email",
+          "password": "Password"
+        },
+        "data_description": {
+          "email": "The email address of your Enphase Enlighten account.",
+          "password": "The password of your Enphase Enlighten account."
+        }
+      }
+    },
+    "error": {
+      "missing_credentials": "Email and password are required."
+    },
+    "abort": {
+      "already_configured": "Account is already configured"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Enphase Envoy Cloud Control options",
+        "description": "Configure polling and notifications. The default polling interval is {interval} seconds.",
+        "data": {
+          "poll_interval": "Polling interval (seconds)",
+          "notifications_enabled": "Enable notifications"
+        }
+      },
+      "schedule_add": {
+        "title": "Add battery schedule",
+        "description": "Create a new battery schedule in the Enphase cloud.",
+        "data": {
+          "schedule_type": "Schedule type",
+          "start_time": "Start time",
+          "end_time": "End time",
+          "limit": "Limit (%)",
+          "days": "Days"
+        }
+      },
+      "schedule_delete": {
+        "title": "Delete battery schedules",
+        "description": "Select one or more schedules to delete from the Enphase cloud.",
+        "data": {
+          "schedule_ids": "Schedules",
+          "confirm": "Confirm deletion"
+        }
+      }
+    },
+    "error": {
+      "required": "This field is required.",
+      "service_error": "The operation failed. Check the notification or Home Assistant logs for details."
+    },
+    "abort": {
+      "no_schedules": "No schedules available to delete."
+    }
+  }
+}

--- a/custom_components/enphase_envoy_cloud_control/switch.py
+++ b/custom_components/enphase_envoy_cloud_control/switch.py
@@ -1,16 +1,32 @@
+"""Switches for Enphase battery control modes and schedule editor day flags."""
+
 from __future__ import annotations
+
 import asyncio
 import logging
+from typing import Any
+
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from .const import DOMAIN
+
+from .coordinator import EnphaseCoordinator
 from .device import battery_device_info, schedule_editor_device_info
 from .editor import DAY_ORDER, get_coordinator, get_entry_data
+
+__all__ = ["EnphaseEditorDaySwitch", "EnphaseModeSwitch", "async_setup_entry"]
 
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass, entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Enphase mode and editor day switches from a config entry."""
     coordinator = get_coordinator(hass, entry.entry_id)
     data = coordinator.data.get("data", {}) if coordinator.data else {}
     switches = []
@@ -33,7 +49,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
 class EnphaseModeSwitch(CoordinatorEntity, SwitchEntity):
     """Switch representing an Enphase battery control mode."""
 
-    def __init__(self, coordinator, key):
+    def __init__(self, coordinator: EnphaseCoordinator, key: str) -> None:
         super().__init__(coordinator)
         self.key = key
         self.short_mode = key.replace("Control", "")
@@ -43,14 +59,14 @@ class EnphaseModeSwitch(CoordinatorEntity, SwitchEntity):
     # ------------------------------------------------------------------
 
     @property
-    def is_on(self):
+    def is_on(self) -> bool:
         """Return True if the control mode is enabled."""
         try:
             return self.coordinator.data["data"][self.key]["enabled"]
-        except Exception:
+        except (KeyError, TypeError):
             return False
 
-    async def async_turn_on(self):
+    async def async_turn_on(self) -> None:
         """Enable the mode in Enphase Cloud."""
         _LOGGER.info("[Enphase] Turning ON %s", self.short_mode)
         await self.coordinator.hass.async_add_executor_job(
@@ -60,7 +76,7 @@ class EnphaseModeSwitch(CoordinatorEntity, SwitchEntity):
         await asyncio.sleep(5)
         await self.coordinator.async_force_refresh()
 
-    async def async_turn_off(self):
+    async def async_turn_off(self) -> None:
         """Disable the mode in Enphase Cloud."""
         _LOGGER.info("[Enphase] Turning OFF %s", self.short_mode)
         await self.coordinator.hass.async_add_executor_job(
@@ -72,7 +88,7 @@ class EnphaseModeSwitch(CoordinatorEntity, SwitchEntity):
     # ------------------------------------------------------------------
 
     @property
-    def device_info(self):
+    def device_info(self) -> dict[str, Any]:
         """Attach to Enphase Envoy Cloud device."""
         return battery_device_info(self.coordinator.entry.entry_id)
 
@@ -80,7 +96,7 @@ class EnphaseModeSwitch(CoordinatorEntity, SwitchEntity):
 class EnphaseEditorDaySwitch(SwitchEntity):
     """Switch representing a weekday toggle for schedule editing."""
 
-    def __init__(self, entry_id: str, day_key: str, is_new: bool):
+    def __init__(self, entry_id: str, day_key: str, is_new: bool) -> None:
         self.entry_id = entry_id
         self.day_key = day_key
         self.is_new = is_new
@@ -108,5 +124,5 @@ class EnphaseEditorDaySwitch(SwitchEntity):
         self.async_write_ha_state()
 
     @property
-    def device_info(self):
+    def device_info(self) -> dict[str, Any]:
         return schedule_editor_device_info(self.entry_id)

--- a/custom_components/enphase_envoy_cloud_control/time.py
+++ b/custom_components/enphase_envoy_cloud_control/time.py
@@ -3,15 +3,24 @@
 from __future__ import annotations
 
 from datetime import time
+from typing import Any
 
 from homeassistant.components.time import TimeEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
 from .device import schedule_editor_device_info
 from .editor import get_entry_data
 
+__all__ = ["EnphaseScheduleTime", "async_setup_entry"]
 
-async def async_setup_entry(hass, entry, async_add_entities):
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Set up schedule time entities."""
     async_add_entities(
         [
@@ -36,7 +45,7 @@ def _parse_time(value: str | None) -> time | None:
 class EnphaseScheduleTime(TimeEntity):
     """Time entity for schedule start/end."""
 
-    def __init__(self, entry_id: str, key: str, is_new: bool):
+    def __init__(self, entry_id: str, key: str, is_new: bool) -> None:
         self.entry_id = entry_id
         self.key = key
         self.is_new = is_new
@@ -62,5 +71,5 @@ class EnphaseScheduleTime(TimeEntity):
         self.async_write_ha_state()
 
     @property
-    def device_info(self):
+    def device_info(self) -> dict[str, Any]:
         return schedule_editor_device_info(self.entry_id)

--- a/custom_components/enphase_envoy_cloud_control/translations/en.json
+++ b/custom_components/enphase_envoy_cloud_control/translations/en.json
@@ -12,13 +12,24 @@
           "email": "The email address of your Enphase Enlighten account.",
           "password": "The password of your Enphase Enlighten account."
         }
+      },
+      "reauth_confirm": {
+        "title": "Reauthenticate Enphase Enlighten",
+        "description": "The stored credentials for {email} no longer work. Enter the current password to reconnect.",
+        "data": {
+          "password": "Password"
+        }
       }
     },
     "error": {
-      "missing_credentials": "Email and password are required."
+      "missing_credentials": "Email and password are required.",
+      "invalid_auth": "Authentication failed. Check the email and password (and that the account can access a battery system).",
+      "cannot_connect": "Could not reach the Enphase cloud. Check your connection and try again."
     },
     "abort": {
-      "already_configured": "Account is already configured"
+      "already_configured": "Account is already configured",
+      "reauth_successful": "Reauthentication was successful.",
+      "reauth_failed": "Reauthentication failed: the config entry no longer exists."
     }
   },
   "options": {

--- a/custom_components/enphase_envoy_cloud_control/translations/en.json
+++ b/custom_components/enphase_envoy_cloud_control/translations/en.json
@@ -1,0 +1,62 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connect to Enphase Enlighten",
+        "description": "Enter your Enphase Enlighten cloud account credentials.",
+        "data": {
+          "email": "Email",
+          "password": "Password"
+        },
+        "data_description": {
+          "email": "The email address of your Enphase Enlighten account.",
+          "password": "The password of your Enphase Enlighten account."
+        }
+      }
+    },
+    "error": {
+      "missing_credentials": "Email and password are required."
+    },
+    "abort": {
+      "already_configured": "Account is already configured"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Enphase Envoy Cloud Control options",
+        "description": "Configure polling and notifications. The default polling interval is {interval} seconds.",
+        "data": {
+          "poll_interval": "Polling interval (seconds)",
+          "notifications_enabled": "Enable notifications"
+        }
+      },
+      "schedule_add": {
+        "title": "Add battery schedule",
+        "description": "Create a new battery schedule in the Enphase cloud.",
+        "data": {
+          "schedule_type": "Schedule type",
+          "start_time": "Start time",
+          "end_time": "End time",
+          "limit": "Limit (%)",
+          "days": "Days"
+        }
+      },
+      "schedule_delete": {
+        "title": "Delete battery schedules",
+        "description": "Select one or more schedules to delete from the Enphase cloud.",
+        "data": {
+          "schedule_ids": "Schedules",
+          "confirm": "Confirm deletion"
+        }
+      }
+    },
+    "error": {
+      "required": "This field is required.",
+      "service_error": "The operation failed. Check the notification or Home Assistant logs for details."
+    },
+    "abort": {
+      "no_schedules": "No schedules available to delete."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR has two parts: a behaviour-preserving **code-quality pass** (first 5 commits) and the **feature roadmap implementation** (last 4 commits, version 1.7.0).

---

## Part 1 — Code quality (behaviour-preserving)

- **Bug fix:** `options_flow.py` used the removed `hass.components.persistent_notification` API — error notifications were silently broken; replaced with the supported pattern.
- **Bug fix:** removed the dead duplicate `EnphaseSchedulesSummarySensor` definition in `sensor.py`.
- Auth failures surface as a self-dismissing persistent notification instead of silent log entries; setup failures raise `ConfigEntryNotReady` (backoff retry).
- `enphase_client.py`: full type hints; duplicated header construction and 403-retry blocks extracted into `_build_headers()` / `_request_with_retry()` (all three header variants verified byte-identical, `validate_schedule` keeps no-retry).
- Narrowed silent `except` blocks; fixed f-string logging; debug logging around login/token refresh/API calls; module docstrings + `__all__` everywhere; `strings.json` + `translations/en.json` added; manifest version synced.
- **UX:** the "Enphase Schedule Selected" dropdown shows readable labels (`CFG 02:00–06:00 · Mon, Tue · 80%`) instead of UUIDs; the UUID stays in editor state, is exposed as a `schedule_id` attribute, and is still accepted by `select_option` for backwards compatibility.

## Part 2 — Features (v1.7.0)

- **Multi-account support:** each config entry now owns its own HTTP session and token cache (`.cache/auth_<entry_id>.json`, with migration from the legacy file and an email guard). Previously a module-level shared session made a second account impossible.
- **Reauth flow + credential validation (fixes password-change lockouts):** setup performs a real Enlighten login and shows `invalid_auth` / `cannot_connect` inline; if credentials later stop working, two failures are tolerated as transient (notification + retry), the third raises `ConfigEntryAuthFailed` so HA shows the standard **Reauthenticate** prompt (password only, entry reloaded in place).
- **Verified deletion (issue #38):** after deleting, the integration re-fetches schedules and raises a clear error if Enphase silently restored them ("feature not enabled for your site"), instead of reporting a false success.
- **Capability pre-check (issue #38):** add/update refuse schedules for modes whose control block is absent from the battery settings payload.
- **Schedule conflict detection:** add/update reject schedules overlapping an existing same-mode schedule on a shared day — including midnight-wrapping windows — before anything reaches the cloud.
- **New read-only sensors** (created only when the payload reports the field; zero extra cloud calls): battery reserve %, system profile, grid mode, very-low SoC threshold.
- **Diagnostics platform:** redacted config/coordinator dump for bug reports.
- **Blueprints + docs:** two importable blueprints (charge-from-grid window, block-discharge window), README glossary for cfg/dtg/rbd, dynamic-tariff automation examples (issue #37), reauth/multi-account/troubleshooting docs.

### Scoped out (and why)
- **Writing the battery profile / AI mode (issue #40)** and **energy import/export sensors (issue #39)**: no verified reverse-engineering exists for those endpoints (the ioBroker port from issue #41 doesn't implement them either). Shipping blind writes against live batteries was judged too risky; the *profile* is now exposed read-only. Happy to add the write path once someone captures the request from the Enlighten UI.

## Verification
- `py_compile` clean on all modules; JSON/YAML validated; `strings.json` ≡ `translations/en.json`.
- Runtime tests: header-variant parity vs the original dicts; per-instance session/cache-key behaviour; overlap detection unit-tested including midnight wrap and touching-endpoints cases; schedule-ID extraction tested against the documented payload shape.
- Greps confirm no remaining f-string logging, removed APIs, or bare excepts.

https://claude.ai/code/session_01X2mJChHiCYaMhG7uNmjK2i