### PR TITLE
Fix duplicated EnphaseSchedulesSummarySensor class with mismatched device binding

### DIFF
--- a/custom_components/enphase_envoy_cloud_control/sensor.py
+++ b/custom_components/enphase_envoy_cloud_control/sensor.py
@@ -132,44 +132,6 @@ class EnphaseSchedulesSummarySensor(CoordinatorEntity, SensorEntity):
         return battery_device_info(self.coordinator.entry.entry_id)
 
 
-class EnphaseSchedulesSummarySensor(CoordinatorEntity, SensorEntity):
-    """Normalized schedule list for editor usage."""
-
-    _attr_name = "Enphase Schedules Summary"
-    _attr_icon = "mdi:calendar-multiple"
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
-
-    def __init__(self, coordinator):
-        super().__init__(coordinator)
-        self._attr_unique_id = f"{coordinator.entry.entry_id}_schedules_summary"
-
-    @property
-    def state(self):
-        schedules = normalize_schedules(self.coordinator)
-        return str(len(schedules))
-
-    @property
-    def extra_state_attributes(self):
-        attrs = {
-            "schedules": normalize_schedules(self.coordinator),
-            "last_refresh": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S%z"),
-        }
-        if getattr(self.coordinator, "last_update_success_time", None):
-            t = self.coordinator.last_update_success_time
-            if isinstance(t, datetime):
-                attrs["last_successful_poll"] = t.strftime("%Y-%m-%dT%H:%M:%S%z")
-        return attrs
-
-    @property
-    def device_info(self):
-        return {
-            "identifiers": {(DOMAIN, self.coordinator.entry.entry_id)},
-            "name": "Enphase Envoy Cloud Control",
-            "manufacturer": "Enphase Energy",
-            "model": "Envoy Cloud API",
-        }
-
-
 # ---------------------------------------------------------------------------
 # PER-MODE SCHEDULE SENSORS
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`sensor.py` accidentally defines `EnphaseSchedulesSummarySensor` **twice**. The second definition silently overrides the first at runtime — and crucially, the two versions attach the sensor to *different devices*.

## The bug

| Definition | `device_info` | Target device |
|---|---|---|
| First (line 102) | `battery_device_info(entry_id)` → name: "Enphase Battery", manufacturer: "Enphase", model: "IQ Battery" | ✅ Consistent with all sibling sensors |
| Second (line 135) — *the winner at runtime* | Inline dict → name: "Enphase Envoy Cloud Control", manufacturer: "Enphase Energy", model: "Envoy Cloud API" | ❌ Spins up an ad-hoc third device |

All other overview sensors (`EnphaseBatteryModesSensor`, `EnphaseScheduleSensor` for cfg/dtg/rbd) use `battery_device_info()`. The second definition would place `sensor.enphase_schedules_summary` on a different device from every sensor it sits alongside — with different manufacturer/model strings to boot.

## The fix

Remove the duplicate definition (old lines 135–171). The first definition remains, preserving the intended device binding and eliminating the confusing double-definition.

## Notes

- Found while auditing README docs against the code — the duplicate was discovered during a documentation review.
- No functional logic differs between the two definitions other than `device_info`, so there is no risk of losing intended behavior.