### PR TITLE
Add home consumption sensors (today/week/month/year/lifetime)

### DIFF
--- a/custom_components/enphase_envoy_cloud_control/coordinator.py
+++ b/custom_components/enphase_envoy_cloud_control/coordinator.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
+from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta, datetime, timezone
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from .const import LOGGER, DEFAULT_POLL_INTERVAL
@@ -31,6 +33,11 @@ class EnphaseCoordinator(DataUpdateCoordinator):
         self.last_refresh = None
         self.last_successful_poll = None
 
+        # Energy stats (today/daily/lifetime) are non-critical and slow. Skip
+        # them on the very first refresh so config-entry setup isn't blocked;
+        # they fill in on the first scheduled poll instead.
+        self._skip_energy = True
+
         super().__init__(
             hass,
             _LOGGER,
@@ -50,11 +57,59 @@ class EnphaseCoordinator(DataUpdateCoordinator):
             _LOGGER.error("[Enphase] Error updating data: %s", err)
             raise UpdateFailed(err)
 
+    @staticmethod
+    def _safe_fetch(label, func, *args):
+        """Call an energy-stats endpoint, returning {} on failure.
+
+        Keeps non-critical energy fetches from aborting the whole update
+        (which would also drop the battery/schedule data).
+        """
+        try:
+            return func(*args) or {}
+        except Exception as err:  # noqa: BLE001 - intentionally broad
+            _LOGGER.warning("[Enphase] %s fetch failed: %s", label, err)
+            return {}
+
+    def _fetch_energy(self):
+        """Fetch the three energy endpoints concurrently.
+
+        Each call is independent and blocking, so running them in a small
+        thread pool collapses their combined latency to roughly the slowest
+        single request. Failures are isolated via _safe_fetch.
+        """
+        # Use HA's configured local time so the month boundary matches the
+        # site's calendar (and the week/year sensor boundaries).
+        month_start = dt_util.now().strftime("%Y-%m-01")
+        with ThreadPoolExecutor(max_workers=3) as pool:
+            today = pool.submit(
+                self._safe_fetch, "today stats", self.client.get_today_stats
+            )
+            daily = pool.submit(
+                self._safe_fetch, "daily energy", self.client.get_daily_energy, month_start
+            )
+            lifetime = pool.submit(
+                self._safe_fetch, "lifetime energy", self.client.get_lifetime_energy
+            )
+            return today.result(), daily.result(), lifetime.result()
+
     def _fetch(self):
         """Synchronous fetch — runs inside executor."""
         try:
             battery_data = self.client.battery_settings() or {}
             schedules = self.client.get_schedules() or {}
+
+            # Energy stats are non-critical and add several blocking HTTP calls.
+            # Skip them on the first refresh so config-entry setup stays fast;
+            # afterwards fetch all three concurrently. When skipped, reuse the
+            # previously fetched values so sensors don't flap to unavailable.
+            if self._skip_energy:
+                self._skip_energy = False
+                prev = self.data or {}
+                today_data = prev.get("today", {}) or {}
+                daily_energy_data = prev.get("daily_energy", {}) or {}
+                lifetime_energy_data = prev.get("lifetime_energy", {}) or {}
+            else:
+                today_data, daily_energy_data, lifetime_energy_data = self._fetch_energy()
 
             # Persist the last schedule payload for entities that reference it
             # outside of the coordinator data structure (legacy behaviour).
@@ -101,6 +156,9 @@ class EnphaseCoordinator(DataUpdateCoordinator):
                 "data": inner_data,
                 "schedules": schedule_block,
                 "schedules_raw": schedules,
+                "today": today_data,
+                "daily_energy": daily_energy_data,
+                "lifetime_energy": lifetime_energy_data,
             }
             _LOGGER.debug("[Enphase] Data fetch complete. Keys: %s", list(merged.keys()))
             return merged

--- a/custom_components/enphase_envoy_cloud_control/enphase_client.py
+++ b/custom_components/enphase_envoy_cloud_control/enphase_client.py
@@ -302,6 +302,76 @@ class EnphaseClient:
         return r.json()
 
     # -------------------------------------------------------------------------
+    # CONSUMPTION / ENERGY STATS
+    # -------------------------------------------------------------------------
+
+    def get_today_stats(self) -> dict[str, Any]:
+        """Fetch today's energy production, consumption, import/export data.
+
+        Calls /pv/systems/{site_id}/today which returns 15-minute interval
+        data and totals (in Wh) for the current day. Only needs the session
+        cookie (no JWT/XSRF required).
+        """
+        site_id = self.battery_id
+        if not site_id:
+            raise AuthError("No site/battery ID available for today stats query.")
+
+        url = f"https://enlighten.enphaseenergy.com/pv/systems/{site_id}/today"
+        r = SESSION.get(url, timeout=30)
+        if r.status_code == 401:
+            _LOGGER.info("[Enphase] Session expired for today stats — re-authenticating.")
+            self._login()
+            r = SESSION.get(url, timeout=30)
+        r.raise_for_status()
+        _LOGGER.debug("[Enphase] Today stats fetched for site %s.", site_id)
+        return r.json()
+
+    def get_daily_energy(self, start_date: str) -> dict[str, Any]:
+        """Fetch daily energy stats from a start date onward.
+
+        Calls /pv/systems/{site_id}/daily_energy?start_date=YYYY-MM-DD
+        which returns an array of per-day stats objects, each with totals
+        in Wh. Only needs the session cookie.
+        """
+        site_id = self.battery_id
+        if not site_id:
+            raise AuthError("No site/battery ID available for daily energy query.")
+
+        url = (
+            f"https://enlighten.enphaseenergy.com/pv/systems/"
+            f"{site_id}/daily_energy?start_date={start_date}"
+        )
+        r = SESSION.get(url, timeout=30)
+        if r.status_code == 401:
+            _LOGGER.info("[Enphase] Session expired for daily energy — re-authenticating.")
+            self._login()
+            r = SESSION.get(url, timeout=30)
+        r.raise_for_status()
+        _LOGGER.debug("[Enphase] Daily energy fetched for site %s from %s.", site_id, start_date)
+        return r.json()
+
+    def get_lifetime_energy(self) -> dict[str, Any]:
+        """Fetch lifetime daily energy arrays.
+
+        Calls /pv/systems/{site_id}/lifetime_energy which returns daily
+        production and consumption arrays (in Wh) since the system was
+        commissioned. Only needs the session cookie.
+        """
+        site_id = self.battery_id
+        if not site_id:
+            raise AuthError("No site/battery ID available for lifetime energy query.")
+
+        url = f"https://enlighten.enphaseenergy.com/pv/systems/{site_id}/lifetime_energy"
+        r = SESSION.get(url, timeout=30)
+        if r.status_code == 401:
+            _LOGGER.info("[Enphase] Session expired for lifetime energy — re-authenticating.")
+            self._login()
+            r = SESSION.get(url, timeout=30)
+        r.raise_for_status()
+        _LOGGER.debug("[Enphase] Lifetime energy fetched for site %s.", site_id)
+        return r.json()
+
+    # -------------------------------------------------------------------------
     # ACTIONS (toggles)
     # -------------------------------------------------------------------------
 

--- a/custom_components/enphase_envoy_cloud_control/sensor.py
+++ b/custom_components/enphase_envoy_cloud_control/sensor.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 import logging
-from datetime import datetime, timezone
-from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
+from datetime import datetime, timedelta, timezone, date
+from homeassistant.components.sensor import SensorEntity, SensorDeviceClass, SensorStateClass
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers.entity import EntityCategory
+from homeassistant.const import UnitOfEnergy
+from homeassistant.util import dt as dt_util
 from .const import DOMAIN
 from .device import battery_device_info
 from .editor import normalize_schedules, get_coordinator
@@ -14,7 +16,15 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up Enphase sensors from a config entry."""
     coordinator = get_coordinator(hass, entry.entry_id)
-    sensors = [EnphaseBatteryModesSensor(coordinator), EnphaseSchedulesSummarySensor(coordinator)]
+    sensors: list[SensorEntity] = [
+        EnphaseBatteryModesSensor(coordinator),
+        EnphaseSchedulesSummarySensor(coordinator),
+        EnphaseTodayConsumptionSensor(coordinator),
+        EnphaseWeekConsumptionSensor(coordinator),
+        EnphaseMonthConsumptionSensor(coordinator),
+        EnphaseYearConsumptionSensor(coordinator),
+        EnphaseLifetimeConsumptionSensor(coordinator),
+    ]
 
     # Add per-mode schedule sensors
     for mode in ["cfg", "dtg", "rbd"]:
@@ -257,4 +267,299 @@ class EnphaseScheduleSensor(CoordinatorEntity, SensorEntity):
     @property
     def device_info(self):
         """Ensure this sensor attaches to the same device as toggles."""
+        return battery_device_info(self.coordinator.entry.entry_id)
+
+
+# ---------------------------------------------------------------------------
+# HELPERS
+# ---------------------------------------------------------------------------
+
+def _today_totals(data: dict | None) -> dict:
+    """Return today's ``totals`` block from the */today* endpoint payload.
+
+    The */today* response nests its daily totals under ``stats[0].totals``
+    (there is no top-level ``totals`` key), so callers must reach through
+    the ``stats`` array.  Returns an empty dict when the data is missing.
+    """
+    if not isinstance(data, dict):
+        return {}
+    today = data.get("today")
+    if not isinstance(today, dict):
+        return {}
+    stats = today.get("stats")
+    if not isinstance(stats, list) or not stats:
+        return {}
+    first = stats[0]
+    if not isinstance(first, dict):
+        return {}
+    totals = first.get("totals")
+    return totals if isinstance(totals, dict) else {}
+
+
+def _sum_lifetime_since(
+    lifetime_energy: dict | None,
+    start_date: date | None,
+) -> int | float | None:
+    """Sum daily Wh values from *start_date* through today (inclusive).
+
+    The */lifetime_energy* ``consumption`` array runs from ``start_date``
+    up to and **including** today as its final element, so today's partial
+    accumulation is already counted — no separate add is required.
+
+    Parameters
+    ----------
+    lifetime_energy
+        Dict from the */lifetime_energy* endpoint with keys ``consumption``
+        (list of int) and ``start_date`` (``"YYYY-MM-DD"``).
+    start_date
+        Inclusive start of the period.  ``None`` means sum everything.
+
+    Returns
+    -------
+    Total Wh or ``None`` when data is missing.
+    """
+    if not isinstance(lifetime_energy, dict):
+        return None
+    consumption = lifetime_energy.get("consumption", [])
+    if not isinstance(consumption, list) or not consumption:
+        return None
+
+    ls = lifetime_energy.get("start_date")
+    if not ls:
+        return None
+
+    try:
+        array_start = datetime.strptime(ls, "%Y-%m-%d").date()
+    except (ValueError, TypeError):
+        return None
+
+    if start_date is not None:
+        days_from_start = (start_date - array_start).days
+        if days_from_start < 0:
+            days_from_start = 0
+        vals = [v for v in consumption[days_from_start:] if isinstance(v, (int, float))]
+    else:
+        vals = [v for v in consumption if isinstance(v, (int, float))]
+
+    if not vals:
+        return None
+
+    return sum(vals)
+
+
+# ---------------------------------------------------------------------------
+# CONSUMPTION SENSORS  (kWh, converted from API Wh via /1000)
+# ---------------------------------------------------------------------------
+
+class EnphaseTodayConsumptionSensor(CoordinatorEntity, SensorEntity):
+    """Today's total home energy consumption (kWh).
+
+    API: /pv/systems/{id}/today  →  totals.consumption
+    Covers: midnight → now.
+    """
+
+    _attr_icon = "mdi:home-lightning-bolt"
+    _attr_name = "Enphase Today Consumption"
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
+
+    def __init__(self, coordinator):
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.entry.entry_id}_today_consumption"
+
+    @property
+    def native_value(self) -> float | None:
+        data = self.coordinator.data or {}
+        totals = _today_totals(data)
+        val = totals.get("consumption")
+        if val is None:
+            return None
+        return round(val / 1000, 3)
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        attrs: dict = {}
+        data = self.coordinator.data or {}
+        today = data.get("today", {}) or {}
+        totals = _today_totals(data)
+        for key in ("production", "consumption", "import", "export",
+                    "charge", "discharge", "solar_home", "battery_home",
+                    "grid_home", "grid_battery", "battery_grid"):
+            val = totals.get(key)
+            if val is not None:
+                attrs[key] = val
+        battery = today.get("battery_details", {}) or {}
+        soc = battery.get("aggregate_soc")
+        if soc is not None:
+            attrs["battery_soc"] = soc
+        last_24h = battery.get("last_24h_consumption")
+        if last_24h is not None:
+            attrs["last_24h_consumption_wh"] = last_24h
+        status = today.get("siteStatus")
+        if status:
+            attrs["site_status"] = status
+        return attrs
+
+    @property
+    def available(self) -> bool:
+        data = self.coordinator.data or {}
+        return _today_totals(data).get("consumption") is not None
+
+    @property
+    def device_info(self):
+        return battery_device_info(self.coordinator.entry.entry_id)
+
+
+class EnphaseWeekConsumptionSensor(CoordinatorEntity, SensorEntity):
+    """This week's total home energy consumption (kWh).
+
+    Period: Monday 00:00 → now.
+    Uses lifetime_energy.consumption, which already includes today.
+    """
+
+    _attr_icon = "mdi:calendar-week"
+    _attr_name = "Enphase Week Consumption"
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
+
+    def __init__(self, coordinator):
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.entry.entry_id}_week_consumption"
+
+    @property
+    def native_value(self) -> float | None:
+        data = self.coordinator.data or {}
+        lifetime = data.get("lifetime_energy", {}) or {}
+        now = dt_util.now()
+        monday = (now - timedelta(days=now.weekday())).date()
+        total_wh = _sum_lifetime_since(lifetime, monday)
+        if total_wh is None:
+            return None
+        return round(total_wh / 1000, 3)
+
+    @property
+    def device_info(self):
+        return battery_device_info(self.coordinator.entry.entry_id)
+
+
+class EnphaseMonthConsumptionSensor(CoordinatorEntity, SensorEntity):
+    """This month's total home energy consumption (kWh).
+
+    Period: 1st of month → now.
+    Uses daily_energy.stats (start_date = YYYY-MM-01), which already
+    includes today's partial data.
+    """
+
+    _attr_icon = "mdi:calendar-month"
+    _attr_name = "Enphase Month Consumption"
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
+
+    def __init__(self, coordinator):
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.entry.entry_id}_month_consumption"
+
+    @property
+    def native_value(self) -> float | None:
+        data = self.coordinator.data or {}
+        daily = data.get("daily_energy", {}) or {}
+        stats = daily.get("stats")
+        if not isinstance(stats, list) or not stats:
+            return None
+        total = 0
+        for day in stats:
+            totals = day.get("totals", {}) if isinstance(day, dict) else {}
+            val = totals.get("consumption")
+            if isinstance(val, (int, float)):
+                total += val
+        return round(total / 1000, 3)
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        data = self.coordinator.data or {}
+        daily = data.get("daily_energy", {}) or {}
+        attrs: dict = {}
+        if daily.get("start_date"):
+            attrs["start_date"] = daily["start_date"]
+        if daily.get("end_date"):
+            attrs["end_date"] = daily["end_date"]
+        return attrs
+
+    @property
+    def device_info(self):
+        return battery_device_info(self.coordinator.entry.entry_id)
+
+
+class EnphaseYearConsumptionSensor(CoordinatorEntity, SensorEntity):
+    """This year's total home energy consumption (kWh).
+
+    Period: January 1st 00:00 → now.
+    Uses lifetime_energy.consumption, which already includes today.
+    """
+
+    _attr_icon = "mdi:calendar"
+    _attr_name = "Enphase Year Consumption"
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
+
+    def __init__(self, coordinator):
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.entry.entry_id}_year_consumption"
+
+    @property
+    def native_value(self) -> float | None:
+        data = self.coordinator.data or {}
+        lifetime = data.get("lifetime_energy", {}) or {}
+        jan1 = dt_util.now().date().replace(month=1, day=1)
+        total_wh = _sum_lifetime_since(lifetime, jan1)
+        if total_wh is None:
+            return None
+        return round(total_wh / 1000, 3)
+
+    @property
+    def device_info(self):
+        return battery_device_info(self.coordinator.entry.entry_id)
+
+
+class EnphaseLifetimeConsumptionSensor(CoordinatorEntity, SensorEntity):
+    """Lifetime home energy consumption (kWh).
+
+    Period: system commissioning → now.
+    Uses all of lifetime_energy.consumption, which already includes today.
+    """
+
+    _attr_icon = "mdi:history"
+    _attr_name = "Enphase Lifetime Consumption"
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
+
+    def __init__(self, coordinator):
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.entry.entry_id}_lifetime_consumption"
+
+    @property
+    def native_value(self) -> float | None:
+        data = self.coordinator.data or {}
+        lifetime = data.get("lifetime_energy", {}) or {}
+        total_wh = _sum_lifetime_since(lifetime, start_date=None)
+        if total_wh is None:
+            return None
+        return round(total_wh / 1000, 3)
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        data = self.coordinator.data or {}
+        lifetime = data.get("lifetime_energy", {}) or {}
+        attrs: dict = {}
+        if lifetime.get("start_date"):
+            attrs["start_date"] = lifetime["start_date"]
+        return attrs
+
+    @property
+    def device_info(self):
         return battery_device_info(self.coordinator.entry.entry_id)


### PR DESCRIPTION
Adds five kWh energy sensors for home consumption (today, week, month, year, lifetime) with the `energy`/`total_increasing` device class, for Predbat and the Energy Dashboard.

Data comes from `/today`, `/daily_energy`, and `/lifetime_energy` (session cookie only). Two shape details: `/today` totals are at `stats[0].totals`, not a top-level `totals`, and `lifetime_energy.consumption` already includes today as its last element, so the week/year/lifetime sums do not add today again (doing so double-counts it).

Period boundaries use HA local time via `dt_util`. The energy fetches are isolated (a failure marks only that sensor unavailable, leaving the battery/schedule entities intact), skipped on the first refresh, and run concurrently afterwards to keep setup under the 10s warning threshold.